### PR TITLE
Fix gulp order so that styles.css gets added correctly.

### DIFF
--- a/styleguide/gulpfile.js
+++ b/styleguide/gulpfile.js
@@ -14,7 +14,8 @@ var gulp        = require('gulp'),
     tagversion  = require('gulp-tag-version'),
     uglify      = require('gulp-uglify'),
     config      = require('./build.config.json');
-    ghPages     = require('gulp-gh-pages');
+    ghPages     = require('gulp-gh-pages'),
+    runSequence = require('run-sequence');
 
 
 // Trigger
@@ -148,13 +149,12 @@ gulp.task('watch', function () {
 gulp.task('default', ['clean:before'], function () {
   production = false;
 
-  gulp.start(
+  // We need to re-run sass last to make sure the latest styles.css gets loaded
+  runSequence(
+    ['scripts', 'fonts', 'images', 'sass'],
     'patternlab',
     'styleguide',
-    'fonts',
-    'sass',
-    'images',
-    'scripts'
+    'sass'
   );
 });
 

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -21,7 +21,9 @@
     "gulp-tag-version": "^1.3.0",
     "gulp-uglify": "^2.0.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "run-sequence": "^1.2.2"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## To test
- pull down branch
- `cd styleguide`
- `npm install` to grab the new dependency
- `rm -rf public/assets` to simulate not having run gulp before
- `gulp serve`

If everything works correctly, `public/assets/css/styles.css` should exist without having to go into a file and save something. :)