### PR TITLE
EWL 3087 - Hero featured load more

### DIFF
--- a/styleguide/source/_meta/_01-foot.twig
+++ b/styleguide/source/_meta/_01-foot.twig
@@ -1,11 +1,12 @@
-  
+
   <!--DO NOT REMOVE-->
   {{ patternLabFoot | raw }}
-  
+
   {# Scripts #}
   {# init js #}
   <script src="../../assets/js/init.js" async></script>
   <script src="../../assets/js/nav.js" async></script>
+  <script src="../../assets/js/featured-content.js" async></script>
   <script src="../../assets/js/search.js" async></script>
   <script src="../../assets/js/tabs-audience-selector.js" async></script>
   <script src="../../assets/js/nav-primary.js" async></script>

--- a/styleguide/source/_patterns/01-molecules/06-components/08-link-more-less/link-more-less.twig
+++ b/styleguide/source/_patterns/01-molecules/06-components/08-link-more-less/link-more-less.twig
@@ -4,6 +4,5 @@
  #}
 
 <div class="link_load_more_less">
-  {% include 'atoms-link-black' with { 'content' : 'Load more'} %}
-  {% include 'atoms-viewmore' %}
+  <a href="{{ url }}" class="link link-black">{{ content|default('Load more') }} {% include 'atoms-viewmore' %}</a>
 </div>

--- a/styleguide/source/_patterns/01-molecules/08-lists/06-list-featured-content-hero/_list-featured-content-hero.scss
+++ b/styleguide/source/_patterns/01-molecules/08-lists/06-list-featured-content-hero/_list-featured-content-hero.scss
@@ -31,3 +31,8 @@
     }
   }
 }
+
+// Hide items after first 3
+.list_featured_content-item:nth-child(n+4) {
+  display: none;
+}

--- a/styleguide/source/_patterns/01-molecules/08-lists/06-list-featured-content-hero/list-featured-content-hero.twig
+++ b/styleguide/source/_patterns/01-molecules/08-lists/06-list-featured-content-hero/list-featured-content-hero.twig
@@ -4,11 +4,29 @@
  #}
 
 <div class="layout layout_one_up list_featured_content-hero">
-  {% include 'atoms-rule-horizontal' %}
-  {% include 'molecules-featured-content-hero-row' %}
-  {% include 'atoms-rule-horizontal' %}
-  {% include 'molecules-featured-content-hero-row' %}
-  {% include 'atoms-rule-horizontal' %}
-  {% include 'molecules-featured-content-hero-row' %}
-  {% include 'atoms-rule-horizontal' %}
+  <div class="list_featured_content-item">
+    {% include 'atoms-rule-horizontal' %}
+    {% include 'molecules-featured-content-hero-row' %}
+    {% include 'atoms-rule-horizontal' %}
+  </div>
+  <div class="list_featured_content-item">
+    {% include 'molecules-featured-content-hero-row' %}
+    {% include 'atoms-rule-horizontal' %}
+  </div>
+  <div class="list_featured_content-item">
+    {% include 'molecules-featured-content-hero-row' %}
+    {% include 'atoms-rule-horizontal' %}
+  </div>
+  <div class="list_featured_content-item">
+    {% include 'molecules-featured-content-hero-row' %}
+    {% include 'atoms-rule-horizontal' %}
+  </div>
+  <div class="list_featured_content-item">
+    {% include 'molecules-featured-content-hero-row' %}
+    {% include 'atoms-rule-horizontal' %}
+  </div>
+  <div class="list_featured_content-item">
+    {% include 'molecules-featured-content-hero-row' %}
+    {% include 'atoms-rule-horizontal' %}
+  </div>
 </div>

--- a/styleguide/source/assets/js/featured-content.js
+++ b/styleguide/source/assets/js/featured-content.js
@@ -1,0 +1,28 @@
+$(document).ready(function() {
+
+  // Hide all items except first 3
+  $('.list_featured_content-item:gt(2)').hide();
+
+  // Create a toggle between Load more and less
+  $('.link_load_more_less a').on('click', function(){
+    var clicks = $(this).data('clicks');
+
+    // Odd click
+    if (clicks) {
+      $(this).text('Load more');
+      $(this).siblings('.icon').removeClass('icon-viewless').addClass('icon-viewmore');
+      $('.list_featured_content-item:gt(2)').slideUp(300);
+    }
+
+    // Event click
+    else {
+      $(this).text('Load less');
+      $(this).siblings('.icon').removeClass('icon-viewmore').addClass('icon-viewless');
+      $('.list_featured_content-item').not(':visible').each( function() {
+        $(this).slideDown(300);
+      });
+    }
+    $(this).data('clicks', !clicks);
+  });
+
+});

--- a/styleguide/source/assets/js/featured-content.js
+++ b/styleguide/source/assets/js/featured-content.js
@@ -9,15 +9,15 @@ $(document).ready(function() {
 
     // Odd click
     if (clicks) {
-      $(this).text('Load more');
-      $(this).siblings('.icon').removeClass('icon-viewless').addClass('icon-viewmore');
+      $(this).contents().first()[0].textContent='Load more ';
+      $(this).children('.icon').removeClass('icon-viewless').addClass('icon-viewmore');
       $('.list_featured_content-item:gt(2)').slideUp(300);
     }
 
-    // Event click
+    // Even click
     else {
-      $(this).text('Load less');
-      $(this).siblings('.icon').removeClass('icon-viewmore').addClass('icon-viewless');
+      $(this).contents().first()[0].textContent='Load less ';
+      $(this).children('.icon').removeClass('icon-viewmore').addClass('icon-viewless');
       $('.list_featured_content-item').not(':visible').each( function() {
         $(this).slideDown(300);
       });


### PR DESCRIPTION
Ticket: https://issues.ama-assn.org/browse/EWL-3087

To test:
- Go to http://localhost:3000/?p=organisms-audience-featured-hero
- On initial page load there should only be three featured items showing
- When you click on the "Load more" link at the bottom, it should slide open the remaining items (6)
- The text should change to "Load less" and the icon should be replaced with a minus
- When you click on the "Load less" link the last three items should slide up and the text of the link should change back to "Load more"

@aCyborg the one markup modification I had to do is wrap each item and its horizontal rule into a `div` so I could hide and show based on item count.