### PR TITLE
EWL - 3112 animate audience selector

### DIFF
--- a/styleguide/source/_patterns/01-molecules/05-navigation/06-tabs-audience-selector/_tabs-audience-selector.scss
+++ b/styleguide/source/_patterns/01-molecules/05-navigation/06-tabs-audience-selector/_tabs-audience-selector.scss
@@ -15,7 +15,6 @@
   border: 1px $gray-8 solid;
   list-style: none;
   margin: 0 0 25px;
-  height: 60px;
   overflow: hidden;
   padding: 0;
   position: relative;

--- a/styleguide/source/_patterns/01-molecules/05-navigation/06-tabs-audience-selector/_tabs-audience-selector.scss
+++ b/styleguide/source/_patterns/01-molecules/05-navigation/06-tabs-audience-selector/_tabs-audience-selector.scss
@@ -13,23 +13,34 @@
 // Audience selector list.
 .tabs-audience_selector_list {
   border: 1px $gray-8 solid;
-  height: 60px;
-  margin-bottom: 25px;
+  list-style: none;
+  margin: 0 0 25px;
   overflow: hidden;
-  padding: 1.1111111111em 0.8333333333em;
+  padding: 0;
   position: relative;
   text-align: center;
 
   .tabs-audience_selector_list_item {
     line-height: 1.3;
-    margin-bottom: 12px;
+    padding: 0;
+    margin-bottom: 0;
+
+    @include breakpoint($bp-med) {
+      margin-right: 0;
+    }
+
+    a {
+      padding: 1em 0.7em;
+
+      &:hover {
+        color: $black-55;
+      }
+    }
   }
 
 
   &.open {
     border: 2px $purple solid;
-    height: auto;
-    overflow: visible;
 
     .tabs-audience_selector_list_item:last-of-type {
       margin-bottom: 0;

--- a/styleguide/source/assets/js/featured-content.js
+++ b/styleguide/source/assets/js/featured-content.js
@@ -1,4 +1,5 @@
-$(document).ready(function() {
+jQuery.noConflict();
+(function($) {
 
   // Hide all items except first 3
   $('.list_featured_content-item:gt(2)').hide();
@@ -25,4 +26,4 @@ $(document).ready(function() {
     $(this).data('clicks', !clicks);
   });
 
-});
+})(jQuery);

--- a/styleguide/source/assets/js/jump-nav.js
+++ b/styleguide/source/assets/js/jump-nav.js
@@ -1,4 +1,5 @@
-$(document).ready(function() {
+jQuery.noConflict();
+(function($) {
   // Search
 
   // When a user clicks on the ribbon trigger (main)
@@ -9,4 +10,4 @@ $(document).ready(function() {
     $(this).parents('#jump-nav').toggleClass('is-closed');
   });
 
-});
+})(jQuery);

--- a/styleguide/source/assets/js/tabs-audience-selector.js
+++ b/styleguide/source/assets/js/tabs-audience-selector.js
@@ -1,10 +1,34 @@
 jQuery.noConflict();
 (function($) {
+
+  // checkWidth function
+  function checkWidth() {
+    if (($(window).width() >= 900)) { // 900px = $bp-med
+      // Show all li selectors
+      $('.tabs-audience_selector_list > li').css('display', 'inline-block');
+    }
+    else {
+      // Display list-item for all li selectors
+      $('.tabs-audience_selector_list > li').css('display', 'list-item');
+      // Hide all li selectors expect first one
+      $('.tabs-audience_selector_list > li:gt(0)').hide();
+    }
+  }
+
+  // Run checkWidth
+  checkWidth();
+  // Re-run checkWidth on window resize
+  $(window).resize(checkWidth);
+
   // Mobile Audience Selector tabs
   $('.tabs-audience_selector_list').click(function () {
-
-    // Add the active class to the list when it is clicked.
-    $(this).toggleClass('open');
+    // If viewport is smaller than 900px
+    if (($(window).width() <= 900)) { // 900px = $bp-med
+      // Add the active class to the list when it is clicked
+      $(this).toggleClass('open');
+      // Toggle hidden items on click
+      $(this).children('li:gt(0)').slideToggle();
+    }
   });
 
 })(jQuery);

--- a/styleguide/source/assets/js/tabs-audience-selector.js
+++ b/styleguide/source/assets/js/tabs-audience-selector.js
@@ -1,9 +1,11 @@
 jQuery.noConflict();
 (function($) {
 
+  var bp_med = 900; // 900px = $bp-med css variable
+
   // checkWidth function
   function checkWidth() {
-    if (($(window).width() >= 900)) { // 900px = $bp-med
+    if (($(window).width() >= bp_med)) {
       // Show all li selectors
       $('.tabs-audience_selector_list > li').css('display', 'inline-block');
     }
@@ -23,7 +25,7 @@ jQuery.noConflict();
   // Mobile Audience Selector tabs
   $('.tabs-audience_selector_list').click(function () {
     // If viewport is smaller than 900px
-    if (($(window).width() < 900)) { // 900px = $bp-med
+    if (($(window).width() < bp_med)) {
       // Add the active class to the list when it is clicked
       $(this).toggleClass('open');
       // Toggle hidden items on click

--- a/styleguide/source/assets/js/tabs-audience-selector.js
+++ b/styleguide/source/assets/js/tabs-audience-selector.js
@@ -23,7 +23,7 @@ jQuery.noConflict();
   // Mobile Audience Selector tabs
   $('.tabs-audience_selector_list').click(function () {
     // If viewport is smaller than 900px
-    if (($(window).width() <= 900)) { // 900px = $bp-med
+    if (($(window).width() < 900)) { // 900px = $bp-med
       // Add the active class to the list when it is clicked
       $(this).toggleClass('open');
       // Toggle hidden items on click


### PR DESCRIPTION
Ticket: https://issues.ama-assn.org/browse/EWL-3112

To test:
- Go to Organisms > Sections > Audience Selector
- If the viewport is less than 900px wide, the Audience Selector should collapse. You should be able to click on the dropdown and the list will slide animate to open. Clicking the list again will slide close.
- If the viewport is more than 900px wide, the Audience Selector should be visible and display inline.