### PR TITLE
Fixes arrow dropping to next line

### DIFF
--- a/styleguide/source/_patterns/01-molecules/05-navigation/07-ribbon-dropdown/_ribbon-dropdown.scss
+++ b/styleguide/source/_patterns/01-molecules/05-navigation/07-ribbon-dropdown/_ribbon-dropdown.scss
@@ -3,7 +3,6 @@
   display: inline-block;
   border-left: 1px solid $gray-8;
   border-right: 1px solid $gray-8;
-  width: 238px;
 }
 
 .ribbon_dropdown_trigger {


### PR DESCRIPTION
Fixed width was causing the arrow to drop to the next line in the the Account Management Center project.

**Before:**
<img width="1431" alt="screen shot 2017-03-09 at 2 10 30 pm" src="https://cloud.githubusercontent.com/assets/3054158/23768616/412f7780-04d2-11e7-87c3-aca1e9e2853f.png">

**After**
<img width="1432" alt="screen shot 2017-03-09 at 2 10 50 pm" src="https://cloud.githubusercontent.com/assets/3054158/23768617/41313638-04d2-11e7-8695-f7764dbb86c0.png">

