### PR TITLE
EWL 3234 - Audience selector featured content

### DIFF
--- a/styleguide/source/_patterns/01-molecules/05-navigation/06-tabs-audience-selector/_tabs-audience-selector.scss
+++ b/styleguide/source/_patterns/01-molecules/05-navigation/06-tabs-audience-selector/_tabs-audience-selector.scss
@@ -126,7 +126,7 @@
 
     @include breakpoint($bp-med min-width) {
       fill: $blue;
-      display: block;
+      display: none;
       margin: 0 auto;
       position: relative;
       right: initial;
@@ -137,6 +137,13 @@
         position: absolute;
         top: 0;
       }
+    }
+  }
+
+  // Show icon for active selector
+  .active .icon-select {
+    @include breakpoint($bp-med min-width) {
+      display: block;
     }
   }
 }

--- a/styleguide/source/_patterns/01-molecules/05-navigation/06-tabs-audience-selector/tabs-audience-selector.twig
+++ b/styleguide/source/_patterns/01-molecules/05-navigation/06-tabs-audience-selector/tabs-audience-selector.twig
@@ -6,9 +6,9 @@
 <div class="tabs tabs-audience_selector">
   <label class="tabs-audience_selector_label">Find trusted info for:</label>
   <ul class="tabs-audience_selector_list">
-    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" class="active">Physicians{% include "atoms-arrow-select" %} </a></li>
-    <li class="tabs-audience_selector_list_item"><a href="{{ url }}">Residents</a></li>
-    <li class="tabs-audience_selector_list_item"><a href="{{ url }}">Med Students</a></li>
-    <li class="tabs-audience_selector_list_item"><a href="{{ url }}">Patients</a></li>
+    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-1" class="active">Physicians{% include "atoms-arrow-select" %} </a></li>
+    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-2">Residents{% include "atoms-arrow-select" %} </a></li>
+    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-3">Med Students{% include "atoms-arrow-select" %} </a></li>
+    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-4">Patients{% include "atoms-arrow-select" %} </a></li>
   </ul>
 </div>

--- a/styleguide/source/_patterns/01-molecules/08-lists/06-list-featured-content-hero/_list-featured-content-hero.scss
+++ b/styleguide/source/_patterns/01-molecules/08-lists/06-list-featured-content-hero/_list-featured-content-hero.scss
@@ -31,8 +31,3 @@
     }
   }
 }
-
-// Hide items after first 3
-.list_featured_content-item:nth-child(n+4) {
-  display: none;
-}

--- a/styleguide/source/_patterns/02-organisms/03-sections/06-audience-featured-hero/_audience-featured-hero.scss
+++ b/styleguide/source/_patterns/02-organisms/03-sections/06-audience-featured-hero/_audience-featured-hero.scss
@@ -6,8 +6,17 @@
 
 .audience_featured-hero {
   width: 100%;
+
   .link_load_more_less {
     margin: 20px 0;
     text-align: center;
+  }
+}
+
+.audience_featured-hero_item {
+  display: none;
+
+  &.active {
+    display: block;
   }
 }

--- a/styleguide/source/_patterns/02-organisms/03-sections/06-audience-featured-hero/audience-featured-hero.twig
+++ b/styleguide/source/_patterns/02-organisms/03-sections/06-audience-featured-hero/audience-featured-hero.twig
@@ -5,6 +5,20 @@
 
 <div class="layout_one_up audience_featured-hero">
   {% include 'molecules-tabs-audience-selector' %}
-  {% include 'molecules-list-featured-content-hero' %}
-  {% include 'molecules-link-more-less' %}
+  <div id="tab-1" class="audience_featured-hero_item active">
+    {% include 'molecules-list-featured-content-hero' %}
+    {% include 'molecules-link-more-less' %}
+  </div>
+  <div id="tab-2" class="audience_featured-hero_item">
+    {% include 'molecules-list-featured-content-hero' %}
+    {% include 'molecules-link-more-less' %}
+  </div>
+  <div id="tab-3" class="audience_featured-hero_item">
+    {% include 'molecules-list-featured-content-hero' %}
+    {% include 'molecules-link-more-less' %}
+  </div>
+  <div id="tab-4" class="audience_featured-hero_item">
+    {% include 'molecules-list-featured-content-hero' %}
+    {% include 'molecules-link-more-less' %}
+  </div>
 </div>

--- a/styleguide/source/assets/js/featured-content.js
+++ b/styleguide/source/assets/js/featured-content.js
@@ -3,7 +3,7 @@ jQuery.noConflict();
 
   // Hide items except first 3
   $('.audience_featured-hero_item').each(function() {
-    $(this).find('.list_featured_content-item:gt(2)').addClass('show').hide();
+    $(this).find('.list_featured_content-item:gt(2)').addClass('hidden').hide();
   });
 
   // Create a toggle between Load more and less
@@ -11,33 +11,33 @@ jQuery.noConflict();
 
     // Featured content path variable
     var featuredContent = '.audience_featured-hero_item.active .list_featured_content-item';
-    var featuredContentHide = $(featuredContent+'.hide');
-    var featuredContentShow = $(featuredContent+'.show');
+    var featuredContentShown = $(featuredContent+'.shown');
+    var featuredContentHidden = $(featuredContent+'.hidden');
 
     // If featured content has show class do this
-    if($(featuredContent).hasClass('show')) {
+    if($(featuredContent).hasClass('hidden')) {
 
       // Updated link text and icon
       $(this).contents().first()[0].textContent='Load less ';
       $(this).children('.icon').removeClass('icon-viewmore').addClass('icon-viewless');
 
       // Slide open hidden content on click
-      featuredContentShow.each(function() {
-        $(this).removeClass('show').addClass('hide');
+      featuredContentHidden.each(function() {
+        $(this).removeClass('hidden').addClass('shown');
         $(this).slideDown(300);
       });
     }
 
     // If featured content has hide class do this
-    else if($(featuredContent).hasClass('hide')) {
+    else if($(featuredContent).hasClass('shown')) {
 
       // Updated link text and icon
       $(this).contents().first()[0].textContent='Load more ';
       $(this).children('.icon').removeClass('icon-viewless').addClass('icon-viewmore');
 
       // Slide close hidden content on click
-      featuredContentHide.each(function() {
-        $(this).removeClass('hide').addClass('show');
+      featuredContentShown.each(function() {
+        $(this).removeClass('shown').addClass('hidden');
         $(this).slideUp(300);
       });
     };

--- a/styleguide/source/assets/js/featured-content.js
+++ b/styleguide/source/assets/js/featured-content.js
@@ -1,29 +1,62 @@
 jQuery.noConflict();
 (function($) {
 
-  // Hide all items except first 3
-  $('.list_featured_content-item:gt(2)').hide();
+  // Hide items except first 3
+  $('.audience_featured-hero_item').each(function() {
+    $(this).find('.list_featured_content-item:gt(2)').addClass('show').hide();
+  });
 
   // Create a toggle between Load more and less
-  $('.link_load_more_less a').on('click', function(){
-    var clicks = $(this).data('clicks');
+  $('.link_load_more_less a').on('click', function() {
 
-    // Odd click
-    if (clicks) {
-      $(this).contents().first()[0].textContent='Load more ';
-      $(this).children('.icon').removeClass('icon-viewless').addClass('icon-viewmore');
-      $('.list_featured_content-item:gt(2)').slideUp(300);
-    }
+    // Featured content path variable
+    var featuredContent = '.audience_featured-hero_item.active .list_featured_content-item';
+    var featuredContentHide = $(featuredContent+'.hide');
+    var featuredContentShow = $(featuredContent+'.show');
 
-    // Even click
-    else {
+    // If featured content has show class do this
+    if($(featuredContent).hasClass('show')) {
+
+      // Updated link text and icon
       $(this).contents().first()[0].textContent='Load less ';
       $(this).children('.icon').removeClass('icon-viewmore').addClass('icon-viewless');
-      $('.list_featured_content-item').not(':visible').each( function() {
+
+      // Slide open hidden content on click
+      featuredContentShow.each(function() {
+        $(this).removeClass('show').addClass('hide');
         $(this).slideDown(300);
       });
     }
-    $(this).data('clicks', !clicks);
+
+    // If featured content has hide class do this
+    else if($(featuredContent).hasClass('hide')) {
+
+      // Updated link text and icon
+      $(this).contents().first()[0].textContent='Load more ';
+      $(this).children('.icon').removeClass('icon-viewless').addClass('icon-viewmore');
+
+      // Slide close hidden content on click
+      featuredContentHide.each(function() {
+        $(this).removeClass('hide').addClass('show');
+        $(this).slideUp(300);
+      });
+    };
+
+  });
+
+  // Audience tab interaction
+  $('.tabs-audience_selector_list_item a').click(function() {
+
+    // Tab data variable
+    var tab_id = $(this).attr('data-tab');
+
+    // Remove classes
+    $('.tabs-audience_selector_list_item a').removeClass('active');
+    $('.audience_featured-hero_item').removeClass('active');
+
+    // Add classes
+    $(this).addClass('active');
+    $('#'+tab_id).addClass('active');
   });
 
 })(jQuery);


### PR DESCRIPTION
Ticket: https://issues.ama-assn.org/browse/EWL-3234

Refactored the show hide functionality for the audience selector. Now the user can tab between each audience as well as show and hide featured content.

To test:
- Visit http://localhost:3000/?p=organisms-audience-featured-hero
- Tab through the audience selector and ensure the content changes.
- Click the load more/less link for each audience.