### PR TITLE
EWL 3077 - Search modal overlay behavior

### DIFF
--- a/styleguide/source/_meta/_01-foot.twig
+++ b/styleguide/source/_meta/_01-foot.twig
@@ -11,6 +11,7 @@
   <script src="../../assets/js/search.js" async></script>
   <script src="../../assets/js/tabs-audience-selector.js" async></script>
   <script src="../../assets/js/nav-primary.js" async></script>
+  <script src="../../assets/js/search-modal.js" async></script>
   <script src="../../assets/js/form-items.js" async></script>
   <script src="../../assets/js/jump-nav.js" async></script>
   </body>

--- a/styleguide/source/_patterns/01-molecules/04-forms/00-search-field/_search-field.scss
+++ b/styleguide/source/_patterns/01-molecules/04-forms/00-search-field/_search-field.scss
@@ -5,8 +5,9 @@
   display: block;
   position: relative;
   width: 100%;
-  height: 175px;
+  //height: 175px;
   border-bottom: 2px solid $blue;
+  padding-top: 100px;
 }
 .search-field_label {
   position: absolute !important;
@@ -17,7 +18,7 @@
     clip: rect(1px 1px 1px 1px); // IE6 and IE7 use the wrong syntax.
   }
   clip: rect(1px, 1px, 1px, 1px);
-} 
+}
 .search-field_input {
   position: absolute;
   bottom: 0;

--- a/styleguide/source/_patterns/01-molecules/04-forms/00-search-field/_search-field.scss
+++ b/styleguide/source/_patterns/01-molecules/04-forms/00-search-field/_search-field.scss
@@ -5,7 +5,6 @@
   display: block;
   position: relative;
   width: 100%;
-  //height: 175px;
   border-bottom: 2px solid $blue;
   padding-top: 100px;
 }

--- a/styleguide/source/_patterns/02-organisms/00-global/02-search_modal/_search_modal.scss
+++ b/styleguide/source/_patterns/02-organisms/00-global/02-search_modal/_search_modal.scss
@@ -1,8 +1,26 @@
 .search_modal {
-  max-width: 1400px;
+  display: none;
+  @extend %clearfix;
+  margin: 0 auto;
+  max-width: 1200px;
   position: relative;
+
+  &.is-open {
+    display: block;
+  }
+}
+
+.search_modal_inner {
+  @include grid__unit--cols(12);
+  flex-direction: row;
+  justify-content: flex-start;
+  width: 100vw;
+  position: absolute;
+  left: 0;
+  right: 0;
   background-color: $black-7;
   padding-bottom: 50px;
+  z-index: 10;
 }
 
 .search_modal_close {

--- a/styleguide/source/_patterns/02-organisms/00-global/02-search_modal/_search_modal.scss
+++ b/styleguide/source/_patterns/02-organisms/00-global/02-search_modal/_search_modal.scss
@@ -26,7 +26,9 @@
 .search_modal_close {
   position: absolute;
   top: 40px;
-  right: 40px;
+  right: 30px;
+  width: 20px;
+  height: 20px;
   color: transparent;
   z-index: 1;
   cursor: pointer;

--- a/styleguide/source/_patterns/02-organisms/00-global/02-search_modal/search_modal.twig
+++ b/styleguide/source/_patterns/02-organisms/00-global/02-search_modal/search_modal.twig
@@ -1,4 +1,4 @@
-<section class="search_modal">
+<div class="search_modal_inner">
   <span class="search_modal_close">
     {% include "atoms-close" %}
     Close
@@ -6,11 +6,10 @@
   <div class="layout layout_one_up">
     {% include "molecules-search-field" %}
   </div>
-
   <div class="layout layout_two_up-heavy-left">
     <div class="layout_two_up-heavy-left-primary">
       {% include "molecules-list-best-match" %}
       {% include "molecules-list-popular-search" %}
     </div>
   </div>
-</section>
+</div>

--- a/styleguide/source/_patterns/03-templates/01-home/01-home.twig
+++ b/styleguide/source/_patterns/03-templates/01-home/01-home.twig
@@ -5,6 +5,9 @@
 
 {% include 'organisms-ribbon' %}
 {% include 'organisms-header-primary' %}
+<section class="search_modal">
+  {% include 'organisms-search_modal' %}
+</section>
 <div class="layout layout-home">
   {% include 'organisms-audience-featured-hero' %}
   {% include 'molecules-page-level-search' %}

--- a/styleguide/source/assets/js/nav-primary.js
+++ b/styleguide/source/assets/js/nav-primary.js
@@ -16,13 +16,23 @@ jQuery.noConflict();
       $(this).toggleClass('nav-primary-menu_button-clicked');
       // toggle the open or closed class on the drawer
       $('.nav-primary_list').toggleClass('nav-primary_list-closed nav-primary_list-open');
-      // When the menu is open, apply the overlay.
-      $('.nav-primary-menu_overlay-mobile').toggleClass('nav-primary-menu_overlay-mobile-on');
       // remove active classes on children
       $('.nav-primary_list-item_title').removeClass('is-active');
       $('.nav-primary_list-item').removeClass('is-active');
       $('.nav-primary_list_subnav').removeClass('is-open');
       $('.nav-primary_list-item').removeClass('is-hidden');
+      // remove is-open class on search modal
+      $('.search_modal').removeClass('is-open');
+
+      // When the menu is open, apply the overlay.
+      if( $('.nav-primary_list').hasClass('nav-primary_list-open') ) {
+        $('.nav-primary-menu_overlay-mobile').addClass('nav-primary-menu_overlay-mobile-on');
+      }
+
+      // Else remove overlay class
+      else {
+        $('.nav-primary-menu_overlay-mobile').removeClass('nav-primary-menu_overlay-mobile-on');
+      };
     }
   });
 
@@ -47,6 +57,8 @@ jQuery.noConflict();
       $(this).parents('.nav-primary_list-item').siblings('.nav-primary_list-item').children('.nav-primary_list-item_title').removeClass('is-active');
       $(this).parents('.nav-primary_list-item').siblings('.nav-primary_list-item').children('.nav-primary_list_subnav').removeClass('is-open');
       $(this).parents('.nav-primary_list-item').siblings('.nav-primary_list-item').removeClass('is-active');
+      // Remove is-open class on search modal
+      $('.search_modal').removeClass('is-open');
 
       if ($(window).width() > 740) {
         setTimeout(function () {
@@ -60,7 +72,7 @@ jQuery.noConflict();
         }, 50);
       }
 
-      if ( $(window).width() < 740 ) { 
+      if ( $(window).width() < 740 ) {
         // hide the other primary items
         $(this).parents('.nav-primary_list-item').siblings('.nav-primary_list-item').toggleClass('is-hidden');
         $(this).parents('.nav-primary_list-item').removeClass('is-hidden');

--- a/styleguide/source/assets/js/search-modal.js
+++ b/styleguide/source/assets/js/search-modal.js
@@ -1,0 +1,40 @@
+/**
+ * @file search-modal.js
+ *
+ * Copyright 2017 Palantir.net, Inc.
+ */
+
+jQuery.noConflict();
+(function($) {
+
+  // Trigger events on search button click
+  $('.button-search').click(function() {
+    // Remove classes for nav dropdowns
+    $('.nav-primary_list-item, .nav-primary_list-item_title').removeClass('is-active');
+    $('.nav-primary_list_subnav').removeClass('is-open');
+
+    // If is-open class exists
+    if( $('.search_modal').hasClass('is-open') ) {
+      $('.search_modal').removeClass('is-open');
+      $('.nav-primary-menu_overlay-mobile').removeClass('nav-primary-menu_overlay-mobile-on');
+    }
+
+    // If is-open class doesn't exist
+    else {
+      $('.search_modal').addClass('is-open');
+      $('.nav-primary-menu_overlay-mobile').addClass('nav-primary-menu_overlay-mobile-on');
+    };
+
+    // Remove nav primary list open class and add closed class on search button click
+    if ( $(window).width() < 740 ) {
+      $('.nav-primary_list').removeClass('nav-primary_list-open').addClass('nav-primary_list-closed');
+    };
+  });
+
+  // Remove classes when clicking close
+  $('.search_modal_close').click(function() {
+    $('.search_modal').removeClass('is-open');
+    $('.nav-primary-menu_overlay-mobile').removeClass('nav-primary-menu_overlay-mobile-on');
+  });
+
+})(jQuery);

--- a/styleguide/source/assets/js/search-modal.js
+++ b/styleguide/source/assets/js/search-modal.js
@@ -9,6 +9,7 @@ jQuery.noConflict();
 
   // Trigger events on search button click
   $('.button-search').click(function() {
+
     // Remove classes for nav dropdowns
     $('.nav-primary_list-item, .nav-primary_list-item_title').removeClass('is-active');
     $('.nav-primary_list_subnav').removeClass('is-open');
@@ -23,6 +24,11 @@ jQuery.noConflict();
     else {
       $('.search_modal').addClass('is-open');
       $('.nav-primary-menu_overlay-mobile').addClass('nav-primary-menu_overlay-mobile-on');
+
+      // Focus search input
+      setTimeout(function(){
+        $('.search_modal .search-field_input').focus();
+      }, 300);
     };
 
     // Remove nav primary list open class and add closed class on search button click


### PR DESCRIPTION
Ticket: https://issues.ama-assn.org/browse/EWL-3077

To test:
- Go to http://localhost:3000/?p=templates-home
- Click on the search icon in upper right corner to open the search modal
- When the search modal is opened, the search input should be focused
- Click search icon again to close
- A user should be able to close the search modal by clicking on the close "X" as well
- A user should be able to switch to a primary nav dropdown when the search modal is open by clicking on a top level item
- Check above functionality at all breakpoints