### PR TITLE
EWL-2735: adds aria roles to quicktabs for screen reader.

### DIFF
--- a/styleguide/source/_patterns/01-molecules/05-navigation/06-tabs-audience-selector/tabs-audience-selector.twig
+++ b/styleguide/source/_patterns/01-molecules/05-navigation/06-tabs-audience-selector/tabs-audience-selector.twig
@@ -5,10 +5,10 @@
 
 <div class="tabs tabs-audience_selector">
   <label class="tabs-audience_selector_label">Find trusted info for:</label>
-  <ul class="tabs-audience_selector_list">
-    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-1" class="active">Physicians{% include "atoms-arrow-select" %} </a></li>
-    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-2">Residents{% include "atoms-arrow-select" %} </a></li>
-    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-3">Med Students{% include "atoms-arrow-select" %} </a></li>
-    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-4">Patients{% include "atoms-arrow-select" %} </a></li>
+  <ul class="tabs-audience_selector_list" role="menu">
+    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-1" class="active" role="menuitem">Physicians{% include "atoms-arrow-select" %} </a></li>
+    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-2" role="menuitem">Residents{% include "atoms-arrow-select" %} </a></li>
+    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-3" role="menuitem">Med Students{% include "atoms-arrow-select" %} </a></li>
+    <li class="tabs-audience_selector_list_item"><a href="{{ url }}" data-tab="tab-4" role="menuitem">Patients{% include "atoms-arrow-select" %} </a></li>
   </ul>
 </div>


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
- [EWL-2735: Accessibility | iPhone VoiceOver does not recognized "Find Trusted Info" as a menu](https://issues.ama-assn.org/browse/EWL-2735)


## Description:
Adds aria roles of menu and menu item to the home page audience selector list and list items in order for screen reader to recognized the items as a menu and not links.

## To Test:

- [x] Navigate to Templates > Home > Home
- [x] Using a screen reader, navigate through the home page
- [x] Observe that the Physicians, Residents, Med Students, and Patients items are indicated as menu items, not links.

## Automated Test:
Requires manual testing with a screen reader.


## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
Will require the audience selector on Corporate to be converted to using the pattern from the style guide.


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
