### PR TITLE
Ewl 3477 hub add cta 50 50 video component to styleguide

### DIFF
--- a/styleguide/source/_meta/_01-foot.twig
+++ b/styleguide/source/_meta/_01-foot.twig
@@ -15,6 +15,8 @@
   <script src="../../assets/js/form-items.js" async></script>
   <script src="../../assets/js/jump-nav.js" async></script>
   <script src="../../assets/js/accordion.js" async></script>
+  <script src="../../assets/js/fitvids.js" async></script>
+  <script src="../../assets/js/hub-cta-half-video.js" async></script>
   </body>
 
 </html>

--- a/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/01-video-youtube.md
+++ b/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/01-video-youtube.md
@@ -1,0 +1,5 @@
+---
+el: ".test"
+title: "Video - Youtube"
+---
+Youtube video embedded player PLACEHOLDER DESC

--- a/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/01-video-youtube.md
+++ b/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/01-video-youtube.md
@@ -2,4 +2,4 @@
 el: ".test"
 title: "Video - Youtube"
 ---
-Youtube video embedded player PLACEHOLDER DESC
+An embedded Youtube video player. It consists of an iframe element.

--- a/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/01-video-youtube.twig
+++ b/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/01-video-youtube.twig
@@ -1,0 +1,1 @@
+ <iframe src="https://www.youtube.com/embed/saRh3WnNChM?rel=0&autohide=1&showinfo=0&controls=2&feature=oembed&enablejsapi=1" frameborder="0"></iframe>

--- a/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/01-video-youtube.twig
+++ b/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/01-video-youtube.twig
@@ -1,1 +1,1 @@
- <iframe src="https://www.youtube.com/embed/saRh3WnNChM?rel=0&autohide=1&showinfo=0&controls=2&feature=oembed&enablejsapi=1" frameborder="0"></iframe>
+ <iframe src="https://www.youtube.com/embed/saRh3WnNChM?rel=0&autohide=1&showinfo=0&controls=2&feature=oembed&enablejsapi=1" frameborder="0" class="iframe-video"></iframe>

--- a/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/_01-video-youtube.scss
+++ b/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/_01-video-youtube.scss
@@ -1,23 +1,3 @@
-.hub-cta_video {
-  display: block;
-  width: 100%;
-  background: black;
-
-  @include breakpoint(600px) {
-    width: 50%;
-  }
-}
-
-.hub-cta_video iframe {
-  width: 100%;
+iframe.iframe-video {
   margin: 0;
-  min-height: calc(((100vw -  40px) / 3) * 2);
-
-  @include breakpoint(600px) {
-    min-height: calc((((100vw - 42px) / 2) / 3) * 2);
-  }
-
-  @include breakpoint($bp-large) {
-    min-height: 400px;
-  }
 }

--- a/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/_01-video-youtube.scss
+++ b/styleguide/source/_patterns/00-atoms/08-media/01-video-youtube/_01-video-youtube.scss
@@ -1,0 +1,23 @@
+.hub-cta_video {
+  display: block;
+  width: 100%;
+  background: black;
+
+  @include breakpoint(600px) {
+    width: 50%;
+  }
+}
+
+.hub-cta_video iframe {
+  width: 100%;
+  margin: 0;
+  min-height: calc(((100vw -  40px) / 3) * 2);
+
+  @include breakpoint(600px) {
+    min-height: calc((((100vw - 42px) / 2) / 3) * 2);
+  }
+
+  @include breakpoint($bp-large) {
+    min-height: 400px;
+  }
+}

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
@@ -1,42 +1,59 @@
-.hub-cta-half-text {
-  width: 100%;
+article, article * {
+  //border: solid 1px red;
+}
 
-  @include breakpoint(1000px) {
+.hub-cta-half-text {
+  //display: none;
+  width: 100%;
+  background: $black-7;
+
+  @include breakpoint(800px) {
     width: 50%;
   }
 }
 
 .hub-cta-half-video {
+  width: 100%;
   flex-direction: column;
+  align-items: center;
 
-  @include breakpoint(1000px) {
+  @include breakpoint(800px) {
     flex-direction: row-reverse;
   }
 }
 
 .hub-cta_video {
-  display: block;
+  max-width: 500px;
   width: 100%;
-  background: black;
+  margin: 0 auto;
+  height: 300px;
+  //display: block;
+  //width: 100%;
 
-  @include breakpoint(1000px) {
+  @include breakpoint(800px) {
     width: 50%;
   }
 }
 
 .hub-cta_video iframe.iframe-video {
   width: 100%;
-  min-height: 230px;
+  height: 100%;
+  //min-height: 230px;
 
   @include breakpoint(600px) {
-    min-height: 300px;
+    //min-height: 300px;
   }
 
   @include breakpoint(1000px) {
-    min-height: calc((((100vw - 42px) / 2) / 3) * 2);
+    //min-height: calc((((100vw - 42px) / 2) / 3) * 2);
   }
 
   @include breakpoint($bp-large) {
-    min-height: 400px;
+    //min-height: 400px;
   }
+}
+
+.test-wrapper {
+  height: 100%;
+  width: 100%;
 }

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
@@ -24,14 +24,14 @@ article, article * {
 
 .hub-cta_video {
   width: 100%;
-  height: 300px;
+  //height: 300px;
   background: black;
   //display: block;
   //width: 100%;
 
   @include breakpoint(800px) {
     width: 50%;
-    height: 365px;
+    //height: 365px;
   }
 }
 

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
@@ -1,0 +1,38 @@
+.hub-cta-half-text {
+  width: 100%;
+
+  @include breakpoint(1000px) {
+    width: 50%;
+  }
+}
+
+.hub-cta-half-video {
+  flex-direction: column;
+
+  @include breakpoint(1000px) {
+    flex-direction: row-reverse;
+  }
+}
+
+.hub-cta_video {
+  display: block;
+  width: 100%;
+  background: black;
+
+  @include breakpoint(1000px) {
+    width: 50%;
+  }
+}
+
+.hub-cta_video iframe.iframe-video {
+  width: 100%;
+  min-height: 300px;
+
+  @include breakpoint(1000px) {
+    min-height: calc((((100vw - 42px) / 2) / 3) * 2);
+  }
+
+  @include breakpoint($bp-large) {
+    min-height: 400px;
+  }
+}

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
@@ -23,15 +23,15 @@ article, article * {
 }
 
 .hub-cta_video {
-  max-width: 500px;
   width: 100%;
-  margin: 0 auto;
   height: 300px;
+  background: black;
   //display: block;
   //width: 100%;
 
   @include breakpoint(800px) {
     width: 50%;
+    height: 365px;
   }
 }
 
@@ -56,4 +56,6 @@ article, article * {
 .test-wrapper {
   height: 100%;
   width: 100%;
+  max-width: 500px;
+  margin: 0 auto;
 }

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
@@ -1,9 +1,4 @@
-article, article * {
-  //border: solid 1px red;
-}
-
 .hub-cta-half-text {
-  //display: none;
   width: 100%;
   background: $black-7;
 
@@ -24,38 +19,8 @@ article, article * {
 
 .hub-cta_video {
   width: 100%;
-  //height: 300px;
-  background: black;
-  //display: block;
-  //width: 100%;
 
   @include breakpoint(800px) {
     width: 50%;
-    //height: 365px;
   }
-}
-
-.hub-cta_video iframe.iframe-video {
-  width: 100%;
-  height: 100%;
-  //min-height: 230px;
-
-  @include breakpoint(600px) {
-    //min-height: 300px;
-  }
-
-  @include breakpoint(1000px) {
-    //min-height: calc((((100vw - 42px) / 2) / 3) * 2);
-  }
-
-  @include breakpoint($bp-large) {
-    //min-height: 400px;
-  }
-}
-
-.test-wrapper {
-  height: 100%;
-  width: 100%;
-  max-width: 500px;
-  margin: 0 auto;
 }

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/_hub-cta-half-video.scss
@@ -26,7 +26,11 @@
 
 .hub-cta_video iframe.iframe-video {
   width: 100%;
-  min-height: 300px;
+  min-height: 230px;
+
+  @include breakpoint(600px) {
+    min-height: 300px;
+  }
 
   @include breakpoint(1000px) {
     min-height: calc((((100vw - 42px) / 2) / 3) * 2);

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.md
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.md
@@ -1,0 +1,5 @@
+---
+el: ".hub-cta-half"
+title: "Hub CTA 50/50"
+---
+A Hub CTA 50/50 Video is a variant of the component Hub CTA 50/50. It consists of a title, description, 3x2 space for a video player, and cta button. 

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.md
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.md
@@ -1,5 +1,5 @@
 ---
 el: ".hub-cta-half"
-title: "Hub CTA 50/50"
+title: "Hub CTA 50/50 Video"
 ---
 A Hub CTA 50/50 Video is a variant of the component Hub CTA 50/50. It consists of a title, description, 3x2 space for a video player, and cta button. 

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
@@ -1,4 +1,4 @@
-<article class="hub-cta-half">
+<article class="hub-cta-half hub-cta-half-video">
     <div class="hub-cta_video">
         {% include 'atoms-video-youtube' %}
     </div>

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
@@ -1,0 +1,19 @@
+<article class="hub-cta-half">
+    <div class="hub-cta_image" style="background-image: url(../../assets/images/fpo_3x2.png)">
+    </div>
+    <div class="hub-cta-half-text">
+        {% include 'atoms-h1' with { 'content': 'Lorem ipsum dolor sit amet', 'class': 'hub-cta_title' } %}
+        <ul class="hub-cta_desc">
+            <li>This is a list item in an unordered list</li>
+            <li>An unordered list is a list in which the sequence of items is not important.</li>
+            <li>Lists can be nested inside of each other</li>
+            <li>This is the last list item</li>
+        </ul>
+        {% include 'atoms-button-link-secondary' with { 'content': 'Join the AMA', 'class': 'button-small' } %}
+    </div>
+</article>
+
+{#
+ # @file hub-cta-half.twig
+ # Copyright 2017 Palantir.net, Inc.
+ #}

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
@@ -1,4 +1,3 @@
-<br>
 <article class="hub-cta-half hub-cta-half-video">
     <div class="hub-cta_video">
       {% include 'atoms-video-youtube' %}

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
@@ -1,5 +1,6 @@
 <article class="hub-cta-half">
-    <div class="hub-cta_image" style="background-image: url(../../assets/images/fpo_3x2.png)">
+    <div class="hub-cta_video">
+        {% include 'atoms-video-youtube' %}
     </div>
     <div class="hub-cta-half-text">
         {% include 'atoms-h1' with { 'content': 'Lorem ipsum dolor sit amet', 'class': 'hub-cta_title' } %}
@@ -14,6 +15,5 @@
 </article>
 
 {#
- # @file hub-cta-half.twig
- # Copyright 2017 Palantir.net, Inc.
+ # @file hub-cta-half-video.twig
  #}

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
@@ -1,6 +1,9 @@
+<br>
 <article class="hub-cta-half hub-cta-half-video">
     <div class="hub-cta_video">
-        {% include 'atoms-video-youtube' %}
+        <div class="test-wrapper">
+            {% include 'atoms-video-youtube' %}
+        </div>
     </div>
     <div class="hub-cta-half-text">
         {% include 'atoms-h1' with { 'content': 'Lorem ipsum dolor sit amet', 'class': 'hub-cta_title' } %}

--- a/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
+++ b/styleguide/source/_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video.twig
@@ -1,9 +1,7 @@
 <br>
 <article class="hub-cta-half hub-cta-half-video">
     <div class="hub-cta_video">
-        <div class="test-wrapper">
-            {% include 'atoms-video-youtube' %}
-        </div>
+      {% include 'atoms-video-youtube' %}
     </div>
     <div class="hub-cta-half-text">
         {% include 'atoms-h1' with { 'content': 'Lorem ipsum dolor sit amet', 'class': 'hub-cta_title' } %}

--- a/styleguide/source/_patterns/03-templates/03-hub/hub.twig
+++ b/styleguide/source/_patterns/03-templates/03-hub/hub.twig
@@ -32,6 +32,9 @@
   <div class="layout">
     {% include 'molecules-hub-cta-half' %}
   </div>
+  <div class="layout">
+    {% include 'molecules-hub-cta-half-video' %}
+  </div>
   
 
 </section>

--- a/styleguide/source/assets/css/style.scss
+++ b/styleguide/source/assets/css/style.scss
@@ -173,5 +173,6 @@ So feel free to use any of these approaches. Or don't. It's totally up to you.
 @import "../../_patterns/02-organisms/01-lists/00-related-content/related-content";
 @import "../../_patterns/03-templates/02-article/article";
 @import "../../_patterns/01-molecules/10-search-results/00-search-result/_search-results";
+@import "../../_patterns/01-molecules/09-hub-components/01-hub-cta/hub-cta-half-video";
 @import "../../_patterns/02-organisms/03-sections/10-category-highlights/category-highlights";
 

--- a/styleguide/source/assets/css/style.scss
+++ b/styleguide/source/assets/css/style.scss
@@ -111,6 +111,7 @@ So feel free to use any of these approaches. Or don't. It's totally up to you.
 @import "../../_patterns/00-atoms/04-images/02-image-wrapper/image-wrapper";
 @import "../../_patterns/00-atoms/06-buttons/01-button-search/button-search";
 @import "../../_patterns/00-atoms/06-buttons/02-button/button";
+@import "../../_patterns/00-atoms/08-media/01-video-youtube/01-video-youtube.scss";
 @import "../../_patterns/01-molecules/00-text/00-section-header/section-header";
 @import "../../_patterns/01-molecules/00-text/01-date-block/date-block";
 @import "../../_patterns/01-molecules/02-blocks/00-block-hero/block-hero";

--- a/styleguide/source/assets/js/hub-cta-half-video.js
+++ b/styleguide/source/assets/js/hub-cta-half-video.js
@@ -1,0 +1,6 @@
+jQuery.noConflict();
+(function($) {
+  $(document).ready(function(){
+    $('.hub-cta_video').fitVids();
+  });
+})(jQuery);

--- a/styleguide/source/assets/js/hub-cta-half-video.js
+++ b/styleguide/source/assets/js/hub-cta-half-video.js
@@ -1,6 +1,6 @@
 jQuery.noConflict();
 (function($) {
   $(document).ready(function(){
-    $('.hub-cta_video').fitVids();
+    $('iframe[src*="youtube"]').parent().fitVids();
   });
 })(jQuery);


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-3477: hub add cta 50 50 video component to styleguide](https://issues.ama-assn.org/browse/EWL-3477)


## Description:
Adds the following:
- Atom: "Video Youtube"
- Molecule: "Hub CTA 50/50 Video"
- Hub CTA 50/50 Video molecule as a newly included pattern in the "Hub" Template
- A JS file, hub-cta-half-video.js, where `.fitvids()` is initialized

The most important thing to do in this ticket was prevent the video and thumbnail from being cropped at any viewpoint. @froboy came up with the solution in the attached screenshot, which uses fitvids() to scale the video responsively. Fitvids.js was included in the codebase already, but was not used in the style guide up to this point.

## To Test:
- Navigate to Atoms > Media > Video - Youtube
- Observe that the Media - Youtube atom exists
- Navigate to Molecules > Hub Components > Hub CTA 50/50 Video
- Observe that the Hub CTA 50/50 Video molecule exists and scales responsively as shown in the screenshot 
- Navigate to Templates > Hub > Hub and scroll until you see the Hub CTA 50/50 Video molecule included; verify that it scales responsively as shown in the screenshot 

## Automated Test:
N/A


## Relevant Screenshots/GIFs:
![5050-5](https://cloud.githubusercontent.com/assets/12160398/26079585/e1d03e46-3988-11e7-9ca7-0a3b4d3610f2.gif)



## Remaining Tasks:
N/A


## Additional Notes:
N/A


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
