### PR TITLE
[EWL-3487]: removes gulp instruction to concat js into one file since…

### DIFF
--- a/styleguide/gulpfile.js
+++ b/styleguide/gulpfile.js
@@ -50,9 +50,6 @@ gulp.task('clean:before', function () {
 // Task: Handle scripts
 gulp.task('scripts', function () {
   return gulp.src(config.scripts.files)
-    .pipe(concat(
-      'application.js'
-    ))
     .pipe(gulpif(production, uglify()))
     .pipe(gulpif(production, rename({
       suffix: '.min'


### PR DESCRIPTION
… that isn't used currently

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
- [EWL-3487: Javascript is not recompiled by gulp 'watch' task](https://issues.ama-assn.org/browse/EWL-3487)


## Description:
Removes the instruction to concat all the js into an application.js file from the gulp 'scripts' task because 1. that application.js file never gets referenced and 2. for whatever reason it was preventing gulp from then also copying over the js files, so they were not getting recompiled when the watch was triggered.


## To Test:
- run gulp serve
- edit a js file
- see your edit reflected when browsersync refreshes


## Automated Test:
N/A


## Relevant Screenshots/GIFs:
N/A


## Remaining Tasks:
At some point, we will likely wish to our build to concat the js into one file, minifying and uglifying production builds.


## Additional Notes:
Checked with both Avi and Chelsie to make sure that the bad behavior I was seeing (having to restart the gulp serve process after editing the js) was a real thing and not just an artifact of something off in my setup.


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
