### PR TITLE
EWL-3485 Hub | Visual QA Fixes

### DIFF
--- a/styleguide/source/_patterns/01-molecules/06-components/10-card-cta/_card-cta.scss
+++ b/styleguide/source/_patterns/01-molecules/06-components/10-card-cta/_card-cta.scss
@@ -219,6 +219,10 @@
   }
 }
 
+.hub-card_image + .hub-card_title {
+  margin-top: auto;
+}
+
 .hub-card_desc,
 .card-cta_desc {
   @include type($font-sans-serif, 18px, $font-weight-medium, 1.3888888889);

--- a/styleguide/source/_patterns/01-molecules/06-components/12-hero-banner/_hero-banner.scss
+++ b/styleguide/source/_patterns/01-molecules/06-components/12-hero-banner/_hero-banner.scss
@@ -74,7 +74,7 @@
 .hub-hero_button-container,
 .hero-banner_button-container {
   margin-top: 10px;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 
   a {
     margin: 10px 12px 0;
@@ -170,7 +170,7 @@
 .hero-banner-cta-only {
   min-height: 0;
   text-align: center;
-  padding: 30px;
+  padding: 1em;
   background-color: $black-7;
 
   .hub-hero_title,

--- a/styleguide/source/_patterns/02-organisms/03-sections/01-card-row/_card-row.scss
+++ b/styleguide/source/_patterns/02-organisms/03-sections/01-card-row/_card-row.scss
@@ -1,5 +1,4 @@
 .hub-card-row,
 .card-row {
-  //margin-top: 24px;
   margin-bottom: 24px;
 }

--- a/styleguide/source/_patterns/02-organisms/03-sections/01-card-row/_card-row.scss
+++ b/styleguide/source/_patterns/02-organisms/03-sections/01-card-row/_card-row.scss
@@ -1,5 +1,5 @@
 .hub-card-row,
 .card-row {
-  margin-top: 24px;
+  //margin-top: 24px;
   margin-bottom: 24px;
 }

--- a/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
+++ b/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
@@ -7,6 +7,17 @@
 .hub-header {
   padding: 0 25px;
   background-color: $purple;
+
+    @include breakpoint(1000px) {
+      position: fixed;
+      width: 100%;
+      top: 0;
+      z-index: 5000000;
+
+      &+.layout {
+        margin-top: 87px;
+    }
+  }
 }
 
 .hub-header-inner {

--- a/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
+++ b/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
@@ -12,7 +12,7 @@
       position: fixed;
       width: 100%;
       top: 0;
-      z-index: 5000000;
+      z-index: 100;
 
       &+.layout {
         margin-top: 87px;

--- a/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
+++ b/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
@@ -92,6 +92,7 @@
   margin-left: auto;
   color: $white;
   order: 1;
+  text-align: right;
 
   .hub-header_cta {
     display: none;

--- a/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
+++ b/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
@@ -108,6 +108,7 @@
     margin-left: 20px;
     max-width: 250px;
     text-align: right;
+    min-width: unset;
 
     .hub-header_cta {
       display: inline-block;

--- a/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
+++ b/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
@@ -14,7 +14,8 @@
       top: 0;
       z-index: 100;
 
-      &+.layout {
+      &+ .layout,
+      &+ article {
         margin-top: 87px;
     }
   }

--- a/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
+++ b/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
@@ -92,7 +92,7 @@
   margin-left: auto;
   color: $white;
   order: 1;
-  text-align: right;
+
 
   .hub-header_cta {
     display: none;
@@ -107,6 +107,7 @@
   @include breakpoint(1000px) {
     margin-left: 20px;
     max-width: 250px;
+    text-align: right;
 
     .hub-header_cta {
       display: inline-block;

--- a/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
+++ b/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
@@ -49,7 +49,7 @@
   .button-secondary {
     @extend %type-small;
     order: 2;
-    padding: 10px 25px;
+    padding: 7px 20px;
     margin-left: auto;
 
     @include breakpoint($bp-small) {

--- a/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
+++ b/styleguide/source/_patterns/02-organisms/04-hub/00-hub-header/_hub-header.scss
@@ -8,7 +8,7 @@
   padding: 0 25px;
   background-color: $purple;
 
-    @include breakpoint(1000px) {
+    @include breakpoint($bp-med) {
       position: fixed;
       width: 100%;
       top: 0;


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-3485: Hub | Visual QA Fixes](https://issues.ama-assn.org/browse/EWL-3485)


## Description:
Various CSS changes in accordance with visual QA.

These changes mirror changes on the Corporate site: https://github.com/AmericanMedicalAssociation/AMA-Corporate-site/pull/1032


## To Test:
Navigate to Templates > Hub > Hub and verify changes are correct according to visual QA:
- [x] Primary CTA top/bottom padding should be same as `.button-small`.
- [x] `.hub-hero-cta-only` padding top/bottom 1.5em -> 1em.
- [x] `.hub-hero-button-container` margin top/bottom 20px -> 10px.
- [x] On Image & Text cards `.hub-card-image + .hub-card-title` should get `margin-top:auto` so that all card CTAs float to bottom.
- [x] `.hub-header-small` (secondary text and CTA) get right aligned, remove min-width
- [x] Ribbon should be sticky to the top of page (desktop)


## Automated Test:
N/A (why does the SG template have a section for this?)

## Relevant Screenshots/GIFs:
![3485-sg-1](https://cloud.githubusercontent.com/assets/12160398/26370754/64b465ea-3fbe-11e7-8555-7f07d561dc8c.png)
![3485-sg-2](https://cloud.githubusercontent.com/assets/12160398/26370758/68ab6298-3fbe-11e7-9d9b-1be59ecbfe26.png)
![3485-3](https://cloud.githubusercontent.com/assets/12160398/26370761/6c96e59e-3fbe-11e7-8d4a-435c68f73fec.png)
![3485-4](https://cloud.githubusercontent.com/assets/12160398/26370764/6e855b4c-3fbe-11e7-9245-14ce54e48242.png)


## Remaining Tasks:
- Investigate heights of row cards in IE11 - broken out into [EWL-3518](https://issues.ama-assn.org/browse/EWL-3518)

## Additional Notes:
N/A


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
