### PR TITLE
Adds placeholder message component

### DIFF
--- a/styleguide/source/_patterns/01-molecules/06-components/14-placeholder-message/_placeholder-message.scss
+++ b/styleguide/source/_patterns/01-molecules/06-components/14-placeholder-message/_placeholder-message.scss
@@ -1,0 +1,9 @@
+.placeholder-message {
+  background: $black-3;
+  border: 2px dashed $black-20;
+  border-radius: 2px;
+  font-size: .8em;
+  margin-bottom: 3em;
+  padding: 3em 2em;
+  text-align: center;
+}

--- a/styleguide/source/_patterns/01-molecules/06-components/14-placeholder-message/placeholder-message.md
+++ b/styleguide/source/_patterns/01-molecules/06-components/14-placeholder-message/placeholder-message.md
@@ -1,0 +1,5 @@
+---
+el: '.placeholder-message'
+title: 'Placeholder Message'
+---
+This is a placeholder message box that appears when a user has not yet entered any content to fill an area. An example might be a contact preferences page that does not have any phone numbers listed.

--- a/styleguide/source/_patterns/01-molecules/06-components/14-placeholder-message/placeholder-message.twig
+++ b/styleguide/source/_patterns/01-molecules/06-components/14-placeholder-message/placeholder-message.twig
@@ -1,0 +1,3 @@
+<div class="placeholder-message">
+  You don't have any phone numbers yet!
+</div>

--- a/styleguide/source/assets/css/style.scss
+++ b/styleguide/source/assets/css/style.scss
@@ -138,6 +138,7 @@ So feel free to use any of these approaches. Or don't. It's totally up to you.
 @import "../../_patterns/01-molecules/06-components/13-accordion/accordion";
 @import '../../_patterns/01-molecules/06-components/12-category-highlight-image/category-highlight-image';
 @import '../../_patterns/01-molecules/06-components/13-subcategory-topics-description/subcategory-topics-description';
+@import "../../_patterns/01-molecules/06-components/14-placeholder-message/placeholder-message";
 @import "../../_patterns/01-molecules/08-lists/00-list_links/list_links";
 @import "../../_patterns/02-organisms/00-global/00-header-primary/header-primary";
 @import "../../_patterns/01-molecules/08-lists/07-list-links-social/list-links-social";


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Github Ticket(s)
- https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/110


## Description:
This component was created for The Account Management Center. It is a placeholder message box that appears when a user has not yet entered any content to fill an area. An example might be a contact preferences page that does not have any phone numbers listed.


## To Test:
- [ ] Navigate to Molecules > Components > Placeholder Message
- [ ] View responsive behavior shown in the gif below


## Automated Test:
N/A

## Relevant Screenshots/GIFs:

**Image of Behavior**
<img width="1400" alt="screen shot 2017-05-17 at 11 45 41 am" src="https://cloud.githubusercontent.com/assets/3054158/26172326/9a216d64-3b0d-11e7-8623-12e71bc5365e.png">


**Video of behavior**
![placeholder_message](https://cloud.githubusercontent.com/assets/3054158/26172287/81310260-3b0d-11e7-9c19-5326a4d0f1c6.gif)


## Remaining Tasks:
N/A

## Additional Notes:
N/A


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
