### PR TITLE
EWL-3518 Hub | Card heights in IE11

### DIFF
--- a/styleguide/source/_patterns/01-molecules/06-components/10-card-cta/_card-cta.scss
+++ b/styleguide/source/_patterns/01-molecules/06-components/10-card-cta/_card-cta.scss
@@ -202,6 +202,7 @@
 .card-cta_image {
   width: 100%;
   order: 1;
+  min-height: 100px;
 }
 
 .hub-card_title,


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWL-3518: Hub | Card heights in IE11](https://issues.ama-assn.org/browse/EWL-3518)


## Description:
This updates the style guide to match the work done in https://github.com/AmericanMedicalAssociation/AMA-Corporate-site/pull/1046.


## To Test:
- [ ] Navigate to Templates > Hub > Hub in IE11
- [ ] Observe that cards are not outrageously tall


## Automated Test:
N/A

## Relevant Screenshots/GIFs:
![screen shot 2017-05-24 at 2 39 36 pm](https://cloud.githubusercontent.com/assets/12160398/26422302/e05de84e-408e-11e7-9afb-e17fc4e34651.png)


## Remaining Tasks:
N/A

## Additional Notes:
N/A


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
