### PR TITLE
[EWL-3063] : adds Issue template for github and minor updates to PR t…

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,86 @@
+<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->
+
+## [Question], [Bug], or [Task]?
+
+Please title your issue according to whether the issue you are reporting is a question, bug or task/feature request.
+
+---
+
+### Question
+
+Ask your question here. A maintainer will try to respond in a timely fashion.
+
+----
+
+### Bug
+
+
+#### Description
+
+Provide a summary of the issue
+
+
+#### Steps to Reproduce
+
+Include system/browser information if relevant
+
+
+#### Expected Result
+
+What do you expect to see?
+
+
+#### Actual Result
+
+What are you actually seeing?
+
+
+#### Relevant Screenshots/GIFs
+
+Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.
+
+
+#### Additional Notes
+
+Anything more to add?
+
+---
+
+### Task/Feature Request
+
+Describe the pattern you think needs to be created and why.
+
+
+#### Components of the pattern
+
+Ex:
+
+ - Molecule 1
+   - Atom 1
+   - Atom 2
+ - Molecule 2
+   - Atom 1
+   - Atom 2
+
+
+#### User Story
+
+Ex:
+
+ - **As an** anonymous user
+ - **I want** to see this organism on this page
+ - **so that** I can know things that the organism is supposed to tell me.
+
+
+#### Acceptance Criteria
+
+Ex:
+
+- When I visit the new organism
+- Then I should see xxxx for the organism
+- and I should see the xxxx for the molecule
+- and I should see the xxxx for the atom
+
+
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,38 @@
 <!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->
 
-## JIRA Ticket(s)
+## Ticket(s)
+
+Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.
+
+**Github Issue**
+
+- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)
+
+**Jira Ticket**
+
 - [EWL-XXXX: Ticket Title](https://issues.ama-assn.org/browse/EWL-XXXX)
 
 
-## Description:
+## Description
+
 Explain the technical implementation of the work done.
 
 
-## To Test:
+## To Test
+
 - [ ] Add steps to test this feature
 
 
-## Automated Test:
-Add a link to the .feature file and also add to the ticket in the Automated Testing field on the JIRA ticket **OR** note why this can not be tested with behat.
+## Relevant Screenshots/GIFs
 
-
-## Relevant Screenshots/GIFs:
 Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.
 
 
-## Remaining Tasks:
+## Remaining Tasks
+
 Remaining tasks?
 
 
-## Additional Notes:
+## Additional Notes
+
 Anything more to add?
-
-
----
-
-[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)


### PR DESCRIPTION
…emplate

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
- [EWL-3063: TEMPLATE - AMA Styleguide Ticket](https://issues.ama-assn.org/browse/EWL-3063)


## Description:
Created an Issue template for the style guide. Took behat testing section out of PR template since it is no longer relevant. Removed the links to Palantir PR documentation since those aren't publicly accessible documents.


## To Test:
- [ ] Look in the .github folder in the project root for the new templates
- [ ] Ensure they don't say anything grossly inaccurate or confusing


## Automated Test:
N/A


## Relevant Screenshots/GIFs:
N/A

## Remaining Tasks:
Update as needed


## Additional Notes:
no.


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
