### PR TITLE
[EWL-3526] : adds a fix for the centered section heading layout in IE11

### DIFF
--- a/styleguide/source/_patterns/01-molecules/00-text/00-section-header/_section-header.scss
+++ b/styleguide/source/_patterns/01-molecules/00-text/00-section-header/_section-header.scss
@@ -10,6 +10,7 @@
   padding-bottom: 30px;
   text-align: center;
   border-bottom: 1px solid $gray-8;
+  width: 100%; //for IE11
 
   @include breakpoint($bp-small) {
     margin-top: 60px;


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
- [EWL-3526: Article Template in IE11](https://issues.ama-assn.org/browse/EWL-3526)


## Description:
Basically just adds a width:100% so the layout doesn't collapse in IE11.


## To Test:
- [x] Using IE11
- [x] Go to Templates > Article
- [x] Observe the layout is better than before


## Automated Test:
N/A


## Relevant Screenshots/GIFs:
Before:
![screen shot 2017-06-02 at 5 16 57 pm](https://cloud.githubusercontent.com/assets/28711067/26746808/7bfb3f02-47b7-11e7-87bf-19fe5ec69048.png)

After:
![screen shot 2017-06-02 at 5 16 12 pm](https://cloud.githubusercontent.com/assets/28711067/26746811/8249543e-47b7-11e7-93de-d54ad1b6571a.png)

## Remaining Tasks:
Should re-check the article template after EWL-3550 and EWL-3551 are completed.


## Additional Notes:
No.


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
