### PR TITLE
[EWL-3574] : creates 5-up layout specified in EC wireframes

### DIFF
--- a/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/_layout-five-up-left.scss
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/_layout-five-up-left.scss
@@ -1,9 +1,3 @@
-/**
- * @file layout-two-up.scss
- *
- * Copyright 2017 Palantir.net, Inc.
- */
-
 // Placeholder blocks in layout molecules.
 .layout_five-up-left {
   &.layout-example .layout_container {

--- a/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/_layout-five-up-left.scss
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/_layout-five-up-left.scss
@@ -1,0 +1,63 @@
+/**
+ * @file layout-two-up.scss
+ *
+ * Copyright 2017 Palantir.net, Inc.
+ */
+
+// Placeholder blocks in layout molecules.
+.layout_five-up-left {
+  &.layout-example .layout_container {
+    background-color: $black-7;
+  }
+  .layout_container {
+    display: block;
+    margin-bottom: 1em;
+    padding: 2em;
+    text-align: center;
+  }
+}
+// Layout default setup.
+
+.flexbox .layout.layout_five-up-left {
+  @include grid__unit--cols(12);
+  justify-content: flex-start;
+}
+
+.layout_five-up-left-primary,
+.layout_five-up-left-secondary {
+  @include grid__unit--cols(12);
+  @include breakpoint($bp-small $bp-med) {
+    @include grid__unit--cols(4);
+  }
+}
+
+.layout_five-up-left-primary {
+  @include breakpoint($bp-med) {
+    @include grid__unit--cols(6);
+    padding-right: 15px;
+  }
+  .layout_container {
+    height: calc(100% - 1em);
+  }
+}
+
+.layout_five-up-left-secondary {
+  @include breakpoint($bp-med) {
+    @include grid__unit--cols(3);
+    padding-left: 15px;
+  }
+}
+
+.layout_five-up-left {
+  @include breakpoint(0 $bp-med) {
+    .layout_container:nth-child(n+2){
+      display: none;
+    }
+  }
+
+  @include breakpoint($bp-small $bp-med) {
+    .layout_container {
+      margin-right: 1em; 
+    }
+  }
+}

--- a/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/_layout-five-up-left.scss
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/_layout-five-up-left.scss
@@ -30,7 +30,7 @@
     @include grid__unit--cols(6);
     padding-right: 15px;
   }
-  .layout_container {
+  .layout_five-up-left-item {
     height: calc(100% - 1em);
   }
 }
@@ -44,13 +44,13 @@
 
 .layout_five-up-left {
   @include breakpoint(0 $bp-med) {
-    .layout_container:nth-child(n+2){
+    .layout_five-up-left-item:nth-child(n+2){
       display: none;
     }
   }
 
   @include breakpoint($bp-small $bp-med) {
-    .layout_container {
+    .layout_five-up-left-item {
       margin-right: 1em; 
     }
   }

--- a/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/_layout-five-up-left.scss
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/_layout-five-up-left.scss
@@ -12,7 +12,7 @@
 }
 // Layout default setup.
 
-.flexbox .layout.layout_five-up-left {
+.layout.layout_five-up-left {
   @include grid__unit--cols(12);
   justify-content: flex-start;
 }

--- a/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.md
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.md
@@ -2,4 +2,6 @@
 el: ".layout-five-up-left"
 title: "Five Up Left Layout"
 ---
-The Five Up Left Layout displays five items, one large item in the left column and two columns of two on the right.
+The Five Up Left Layout displays five items, one large primary item in the left column and two secondary columns of two items on the right.
+
+Can be implemented by adding `.layout-five-up-left` class to a container, `.layout_five-up-left-primary` and `.layout_five-up-left-secondary` classes to the right and left two containers respectively, and `.layout_five-up-left-item` class to individual content blocks.

--- a/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.md
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.md
@@ -1,0 +1,5 @@
+---
+el: ".layout-five-up-left"
+title: "Five Up Left Layout"
+---
+The Five Up Left Layout displays five items, one large item in the left column and two columns of two on the right.

--- a/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.twig
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.twig
@@ -1,13 +1,13 @@
 <div class="layout layout-example layout_five-up-left">
     <div class="layout_five-up-left-primary">
-        <div class="layout_container">5-up</div>
+        <div class="layout_five-up-left-item layout_container">5-up</div>
     </div>
     <div class="layout_five-up-left-secondary">
-        <div class="layout_container">5-up</div>
-        <div class="layout_container">5-up</div>
+        <div class="layout_five-up-left-item layout_container">5-up</div>
+        <div class="layout_five-up-left-item layout_container">5-up</div>
     </div>
     <div class="layout_five-up-left-secondary">
-        <div class="layout_container">5-up</div>
-        <div class="layout_container">5-up</div>
+        <div class="layout_five-up-left-item layout_container">5-up</div>
+        <div class="layout_five-up-left-item layout_container">5-up</div>
     </div>
 </div>

--- a/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.twig
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.twig
@@ -1,8 +1,3 @@
-{#
- # @file layout-two-up.twig
- # Copyright 2017 Palantir.net, Inc.
- #}
-
 <div class="layout layout-example layout_five-up-left">
     <div class="layout_five-up-left-primary">
         <div class="layout_container">5-up</div>

--- a/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.twig
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.twig
@@ -1,0 +1,18 @@
+{#
+ # @file layout-two-up.twig
+ # Copyright 2017 Palantir.net, Inc.
+ #}
+
+<div class="layout layout-example layout_five-up-left">
+    <div class="layout_five-up-left-primary">
+        <div class="layout_container">2-up</div>
+    </div>
+    <div class="layout_five-up-left-secondary">
+        <div class="layout_container">2-up</div>
+        <div class="layout_container">2-up</div>
+    </div>
+    <div class="layout_five-up-left-secondary">
+        <div class="layout_container">2-up</div>
+        <div class="layout_container">2-up</div>
+    </div>
+</div>

--- a/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.twig
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left.twig
@@ -5,14 +5,14 @@
 
 <div class="layout layout-example layout_five-up-left">
     <div class="layout_five-up-left-primary">
-        <div class="layout_container">2-up</div>
+        <div class="layout_container">5-up</div>
     </div>
     <div class="layout_five-up-left-secondary">
-        <div class="layout_container">2-up</div>
-        <div class="layout_container">2-up</div>
+        <div class="layout_container">5-up</div>
+        <div class="layout_container">5-up</div>
     </div>
     <div class="layout_five-up-left-secondary">
-        <div class="layout_container">2-up</div>
-        <div class="layout_container">2-up</div>
+        <div class="layout_container">5-up</div>
+        <div class="layout_container">5-up</div>
     </div>
 </div>

--- a/styleguide/source/assets/css/style.scss
+++ b/styleguide/source/assets/css/style.scss
@@ -167,6 +167,7 @@ So feel free to use any of these approaches. Or don't. It's totally up to you.
 @import "../../_patterns/01-molecules/01-layouts/04-layout-one-up-center/layout-one-up-center";
 @import "../../_patterns/01-molecules/01-layouts/05-layout-two-up-large/layout-two-up-large";
 @import "../../_patterns/01-molecules/01-layouts/06-layout-two-up-heavy-right-offset/layout-two-up-heavy-right-offset";
+@import "../../_patterns/01-molecules/01-layouts/07-layout-five-up-left/layout-five-up-left";
 @import "../../_patterns/03-templates/01-home/01-home";
 @import "../../_patterns/01-molecules/06-components/05-page-level-search/page-level-search";
 @import "../../_patterns/00-atoms/01-global/07-rule-vertical/rule-vertical";


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWL-3574: Create Education Center Marketing Page Template](https://issues.ama-assn.org/browse/EWL-3574)
- [EWL-3622: EC | Design Landscape Image Card & Row - style guide](https://issues.ama-assn.org/browse/EWL-3622)

## Description

Creates pattern for the 5up layout from the EC wireframes.


## To Test

- [ ] Go to Molecules > Layouts > Five Up Left Layout
- [ ] Observe that desktop, tablet, and mobile layouts match wireframe


## Relevant Screenshots/GIFs
<img width="986" alt="screen shot 2017-06-12 at 1 21 53 pm" src="https://user-images.githubusercontent.com/28711067/27048633-356dd6ea-4f72-11e7-9895-71a2b6a31517.png">

<img width="742" alt="screen shot 2017-06-12 at 1 22 06 pm" src="https://user-images.githubusercontent.com/28711067/27048638-38ba94c8-4f72-11e7-96e5-b9a627d63e15.png">

<img width="452" alt="screen shot 2017-06-12 at 1 22 19 pm" src="https://user-images.githubusercontent.com/28711067/27048639-3b48192c-4f72-11e7-9ad1-3c26de292420.png">



## Remaining Tasks
There are other tasks to this ticket (building out the rest of the EC page) but not specific to the 5-up layout.


## Additional Notes

No.
