### PR TITLE
[EWL-3093] : uses gulp to inject js needed to create a scss tab panel

### DIFF
--- a/styleguide/gulpfile.js
+++ b/styleguide/gulpfile.js
@@ -127,6 +127,17 @@ gulp.task('icons', function (callback) {
   runSequence('minifyIcons', 'makeIcons', 'waitForIcons', 'reloadIcons', callback);
 });
 
+// Task: BuildPaths
+// Description: Tell pattern lab to look for scss files
+// TODO: we probably should us a try-catch in here somewhen to suppress errors when no scss exists
+gulp.task('build-paths', function() {
+  gulp.src('vendor/pattern-lab/core/src/PatternLab/Builder.php')
+  .pipe(replace(/: \$patternStoreData\["pathName"];\s+\n/g,': $patternStoreData["pathName"];\n$pathParts = explode("/",$pathName);\narray_pop($pathParts);\n$scssPathName  = implode("/",$pathParts)."/_".$patternStoreData["name"];\n'))
+  .pipe(replace(/\.\$patternExtension\);\s+\n/g, '.$patternExtension);\n$scss = file_get_contents($patternSourceDir."/".$scssPathName.".scss");\n'))
+  .pipe(replace(/,\$markupEngine\);\s+\n*/g,',$markupEngine);\nfile_put_contents($patternPublicDir."/".$path."/".$path.$suffixRaw.".scss",$scss);\n'))
+  .pipe(gulp.dest('vendor/pattern-lab/core/src/PatternLab/'));
+});
+
 // Task: patternlab
 // Description: Build static Pattern Lab files via PHP script
 gulp.task('patternlab', function () {
@@ -224,6 +235,7 @@ gulp.task('default', ['clean:before'], function (callback) {
   runSequence(
     'icons',
     ['scripts', 'fonts', 'images', 'sass'],
+    'build-paths',
     'patternlab',
     'panel-inject',
     'styleguide',

--- a/styleguide/gulpfile.js
+++ b/styleguide/gulpfile.js
@@ -1,37 +1,37 @@
 // npm requirements
-var gulp        = require("gulp"),
-    bump        = require("gulp-bump"),
-    clean       = require("gulp-clean"),
-    concat      = require("gulp-concat"),
-    browserSync = require("browser-sync"),
-    cssmin      = require("gulp-cssmin"),
-    filter      = require("gulp-filter"),
-    git         = require("gulp-git"),
-    gulpif      = require("gulp-if"),
-    imagemin    = require("gulp-imagemin"),
-    rename      = require("gulp-rename"),
-    sass        = require("gulp-sass"),
-    shell       = require("gulp-shell"),
-    tagversion  = require("gulp-tag-version"),
-    uglify      = require("gulp-uglify"),
-    ghPages     = require("gulp-gh-pages"),
-    runSequence = require("run-sequence"),
-    glob        = require("glob"),
-    svgmin      = require("gulp-svgmin"),
-    gulpicon    = require("gulpicon/tasks/gulpicon"),
-    sourcemaps  = require("gulp-sourcemaps"),
-    prefix      = require("gulp-autoprefixer"),
-    postcss     = require("gulp-postcss"),
-    replace     = require("gulp-replace"),
-    reporter    = require("postcss-reporter"),
-    stylelint   = require("gulp-stylelint"),
-    gutil       = require("gulp-util");
-    gutil       = require("gulp-util"),
-    pWaitFor    = require("p-wait-for"),
-    pathExists  = require("path-exists");
+var gulp        = require('gulp'),
+    bump        = require('gulp-bump'),
+    clean       = require('gulp-clean'),
+    concat      = require('gulp-concat'),
+    browserSync = require('browser-sync'),
+    cssmin      = require('gulp-cssmin'),
+    filter      = require('gulp-filter'),
+    git         = require('gulp-git'),
+    gulpif      = require('gulp-if'),
+    imagemin    = require('gulp-imagemin'),
+    rename      = require('gulp-rename'),
+    sass        = require('gulp-sass'),
+    shell       = require('gulp-shell'),
+    tagversion  = require('gulp-tag-version'),
+    uglify      = require('gulp-uglify'),
+    ghPages     = require('gulp-gh-pages'),
+    runSequence = require('run-sequence'),
+    glob        = require('glob'),
+    svgmin      = require('gulp-svgmin'),
+    gulpicon    = require('gulpicon/tasks/gulpicon'),
+    sourcemaps  = require('gulp-sourcemaps'),
+    prefix      = require('gulp-autoprefixer'),
+    postcss     = require('gulp-postcss'),
+    replace     = require('gulp-replace'),
+    reporter    = require('postcss-reporter'),
+    stylelint   = require('gulp-stylelint'),
+    gutil       = require('gulp-util');
+    gutil       = require('gulp-util'),
+    pWaitFor    = require('p-wait-for'),
+    pathExists  = require('path-exists');
 
 // Config
-var config = require("./build.config.json");
+var config = require('./build.config.json');
 
 
 // Trigger
@@ -39,7 +39,7 @@ var production;
 
 // Task: Clean:before
 // Description: Removing assets files before running other tasks
-gulp.task("clean:before", function () {
+gulp.task('clean:before', function () {
   return gulp.src(
     config.assets.dest
   )
@@ -49,22 +49,22 @@ gulp.task("clean:before", function () {
 });
 
 // Task: Handle scripts
-gulp.task("scripts", function () {
+gulp.task('scripts', function () {
   return gulp.src(config.scripts.files)
     // unminified for development
     .pipe(sourcemaps.init())
-    .pipe(concat("app.js"))
+    .pipe(concat('app.js'))
     .pipe(sourcemaps.write())
     .pipe(gulp.dest(config.scripts.dest))
-    // also "production-ready" js file even though we don"t use it yet
-    .pipe(rename("app.min.js"))
+    // also 'production-ready' js file even though we don't use it yet
+    .pipe(rename('app.min.js'))
     .pipe(uglify())
     .pipe(gulp.dest(config.scripts.dest))
     .pipe(browserSync.reload({stream:true}));
 });
 
 // Task: Handle fonts
-gulp.task("fonts", function () {
+gulp.task('fonts', function () {
   return gulp.src(config.fonts.files)
     .pipe(gulp.dest(
       config.fonts.dest
@@ -73,7 +73,7 @@ gulp.task("fonts", function () {
 });
 
 // Task: Handle images
-gulp.task("images", function () {
+gulp.task('images', function () {
   return gulp.src(config.images.files)
     .pipe(gulpif(production, imagemin()))
     .pipe(gulp.dest(
@@ -83,15 +83,15 @@ gulp.task("images", function () {
 });
 
 // Task: Handle Sass and CSS
-gulp.task("sass", function () {
+gulp.task('sass', function () {
   return gulp.src(config.scss.files)
     .pipe(sass())
-    .pipe(prefix("last 2 version"))
+    .pipe(prefix('last 2 version'))
     .pipe(gulpif(production, cssmin()))
     .pipe(gulpif(production, rename({
-      suffix: ".min"
+      suffix: '.min'
     })))
-    .pipe(sourcemaps.write("."))
+    .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest(
       config.scss.dest
     ))
@@ -101,187 +101,187 @@ gulp.task("sass", function () {
 // Task: Handle icons
 // We have to do this in a few steps until
 // https://github.com/filamentgroup/gulpicon/issues/1 is resolved
-gulp.task("minifyIcons", function() {
+gulp.task('minifyIcons', function() {
   return gulp.src(config.icons.files)
       .pipe(svgmin())
       .pipe(gulp.dest(config.icons.min));
 });
 
 // Based on https://github.com/filamentgroup/gulpicon#usage
-var iconFiles = glob.sync("source/assets/icons/svg/*.svg");
-var iconConfig = require("./source/assets/icons/config.js");
-iconConfig.dest = "public/assets/icons/";
-gulp.task("makeIcons", gulpicon(iconFiles, iconConfig));
-gulp.task("waitForIcons", function(callback) {
-  var trigger = iconConfig.dest + "preview.html";
-  return pWaitFor(() => pathExists(trigger, "1000")).then(() => {
-    console.log("Yay! The icons now exist.");
+var iconFiles = glob.sync('source/assets/icons/svg/*.svg');
+var iconConfig = require('./source/assets/icons/config.js');
+iconConfig.dest = 'public/assets/icons/';
+gulp.task('makeIcons', gulpicon(iconFiles, iconConfig));
+gulp.task('waitForIcons', function(callback) {
+  var trigger = iconConfig.dest + 'preview.html';
+  return pWaitFor(() => pathExists(trigger, '1000')).then(() => {
+    console.log('Yay! The icons now exist.');
   });
 });
-gulp.task("reloadIcons", function() {
-  return gulp.src("", {read: false})
+gulp.task('reloadIcons', function() {
+  return gulp.src('', {read: false})
     .pipe(browserSync.reload({stream:true}));
 });
 
-gulp.task("icons", function (callback) {
-  runSequence("minifyIcons", "makeIcons", "waitForIcons", "reloadIcons", callback);
+gulp.task('icons', function (callback) {
+  runSequence('minifyIcons', 'makeIcons', 'waitForIcons', 'reloadIcons', callback);
 });
 
 // Task: patternlab
 // Description: Build static Pattern Lab files via PHP script
-gulp.task("patternlab", function () {
-  return gulp.src("", {read: false})
+gulp.task('patternlab', function () {
+  return gulp.src('', {read: false})
     .pipe(shell([
-      "php core/console --generate"
+      'php core/console --generate'
     ]))
     .pipe(browserSync.reload({stream:true}));
 });
 
 // Task: PanelInject
 // Description: Let us inject a scss panel into patternlab assets js
-gulp.task("panel-inject", function() {
-  gulp.src("public/index.html")
+gulp.task('panel-inject', function() {
+  gulp.src('public/index.html')
     .pipe(replace(/patternlab-viewer\.min\.js\"><\/script>\s+\n/g,'patternlab-viewer.min.js"></script>\n<script>var fileSuffixPattern = ((config.outputFileSuffixes !== undefined) && (config.outputFileSuffixes.rawTemplate !== undefined)) ? config.outputFileSuffixes.rawTemplate : ""; Panels.add({ "id": "sg-panel-scss", "name": "SCSS", "default": false, "templateID": "pl-panel-template-code", "httpRequest": true, "httpRequestReplace": fileSuffixPattern+".scss", "httpRequestCompleted": false, "prismHighlight": true, "language": "markup", "keyCombo": "ctrl+shift+t" });</script>\n'))
-    .pipe(gulp.dest("public"))
+    .pipe(gulp.dest('public'))
 });
 
 // Task: styleguide
 // Description: Copy Styleguide-Folder from core/ to public
-gulp.task("styleguide", function() {
+gulp.task('styleguide', function() {
   return gulp.src(config.patternlab.styleguide.files)
     .pipe(gulp.dest(config.patternlab.styleguide.dest));
 });
 
 // task: BrowserSync
 // Description: Run BrowserSync server with disabled ghost mode
-gulp.task("browser-sync", function() {
+gulp.task('browser-sync', function() {
   browserSync({
     server: {
         baseDir: config.root
     },
     ghostMode: true,
-    open: "local"
+    open: 'local'
   });
 });
 
 // Task: Sass Linting
 // Description: lint sass files
-gulp.task("scss-lint", function() {
+gulp.task('scss-lint', function() {
   return gulp.src(config.scss.files)
     .pipe(stylelint({
       reporters: [
-        {formatter: "string", console: true}
+        {formatter: 'string', console: true}
       ]
     }));
 });
 
 // Task: Watch files
-gulp.task("watch", function () {
+gulp.task('watch', function () {
 
   // Watch Pattern Lab files
   gulp.watch(
     config.patternlab.files,
-    ["patternlab"]
+    ['patternlab']
   );
 
   // Watch scripts
   gulp.watch(
     config.scripts.files,
-    ["scripts"]
+    ['scripts']
   );
 
   // Watch images
   gulp.watch(
     config.images.files,
-    ["images"]
+    ['images']
   );
 
   // Watch Sass
   gulp.watch(
     config.scss.files,
-    ["sass"]
+    ['sass']
   );
 
   // Watch icons
   gulp.watch(
     config.icons.files,
-    ["icons"]
+    ['icons']
   );
 
   // Watch fonts
   gulp.watch(
     config.fonts.files,
-    ["fonts"]
+    ['fonts']
   );
 });
 
 // Task: Default
 // Description: Build all stuff of the project once
-gulp.task("default", ["clean:before"], function (callback) {
+gulp.task('default', ['clean:before'], function (callback) {
   production = false;
 
   // We need to re-run sass last to make sure the latest styles.css gets loaded
   runSequence(
-    "icons",
-    ["scripts", "fonts", "images", "sass"],
-    "patternlab",
-    "panel-inject",
-    "styleguide",
-    "sass",
+    'icons',
+    ['scripts', 'fonts', 'images', 'sass'],
+    'patternlab',
+    'panel-inject',
+    'styleguide',
+    'sass',
     callback
   );
 });
 
 // Task: Start your production-process
-// Description: Type "gulp" in the terminal
-gulp.task("serve", function () {
+// Description: Type 'gulp' in the terminal
+gulp.task('serve', function () {
   production = false;
 
   runSequence(
-    "default",
-    "browser-sync",
-    "watch"
+    'default',
+    'browser-sync',
+    'watch'
   );
 });
 
 // Task: Publish static content
 // Description: Publish static content using rsync shell command
-gulp.task("publish", function () {
+gulp.task('publish', function () {
   return gulp.src(config.deployment.local.path)
     .pipe(ghPages());
 });
 
 // Task: Deploy to GitHub pages
 // Description: Build the public code and deploy it to GitHub pages
-gulp.task("deploy", function () {
+gulp.task('deploy', function () {
   // make sure to use the gulp from node_modules and not a different version
-  runSequence = require("run-sequence").use(gulp);
+  runSequence = require('run-sequence').use(gulp);
   // run default to build the code and then publish it GitHub pages
-  runSequence("default", "publish");
+  runSequence('default', 'publish');
 });
 
 // Function: Releasing (Bump, Tagging & Deploying)
 // Description: Bump npm versions, create Git tag and push to origin
-gulp.task("tag", function () {
+gulp.task('tag', function () {
   production = true;
 
   return gulp.src(config.versioning.files)
     .pipe(bump({
-      type: gutil.env.env || "development"
+      type: gutil.env.env || 'development'
     }))
-    .pipe(gulp.dest("./"))
-    .pipe(git.commit("Release a " + gutil.env.env + "-update"))
+    .pipe(gulp.dest('./'))
+    .pipe(git.commit('Release a ' + gutil.env.env + '-update'))
 
     // read only one file to get version number
-    .pipe(filter("package.json"))
+    .pipe(filter('package.json'))
 
     // Tag it
     .pipe(tagversion())
 
     // Publish files and tags to endpoint
     .pipe(shell([
-      "git push origin develop",
-      "git push origin --tags"
+      'git push origin develop',
+      'git push origin --tags'
     ]));
 });
 
@@ -289,9 +289,9 @@ gulp.task("tag", function () {
 // Description: Release runs default to build the files,
 // runs tag to tag the release and pushes that to GitHub
 // runs publish to also make sure GitHub pages site is updated
-gulp.task("release", function () {
+gulp.task('release', function () {
   // make sure to use the gulp from node_modules and not a different version
-  runSequence = require("run-sequence").use(gulp);
+  runSequence = require('run-sequence').use(gulp);
   // run default to build the code, next tag to cut a tag, then publish to deploy to GitHub pages
-  runSequence("default", "tag", "publish");
+  runSequence('default', 'tag', 'publish');
 });

--- a/styleguide/gulpfile.js
+++ b/styleguide/gulpfile.js
@@ -1,36 +1,37 @@
 // npm requirements
-var gulp        = require('gulp'),
-    bump        = require('gulp-bump'),
-    clean       = require('gulp-clean'),
-    concat      = require('gulp-concat'),
-    browserSync = require('browser-sync'),
-    cssmin      = require('gulp-cssmin'),
-    filter      = require('gulp-filter'),
-    git         = require('gulp-git'),
-    gulpif      = require('gulp-if'),
-    imagemin    = require('gulp-imagemin'),
-    rename      = require('gulp-rename'),
-    sass        = require('gulp-sass'),
-    shell       = require('gulp-shell'),
-    tagversion  = require('gulp-tag-version'),
-    uglify      = require('gulp-uglify'),
-    ghPages     = require('gulp-gh-pages'),
-    runSequence = require('run-sequence'),
-    glob        = require('glob'),
-    svgmin      = require('gulp-svgmin'),
-    gulpicon    = require('gulpicon/tasks/gulpicon'),
-    sourcemaps  = require('gulp-sourcemaps'),
-    prefix      = require('gulp-autoprefixer'),
-    postcss     = require('gulp-postcss'),
-    reporter    = require('postcss-reporter'),
-    stylelint   = require('gulp-stylelint'),
-    gutil       = require('gulp-util');
-    gutil       = require('gulp-util'),
-    pWaitFor    = require('p-wait-for'),
-    pathExists  = require('path-exists');
+var gulp        = require("gulp"),
+    bump        = require("gulp-bump"),
+    clean       = require("gulp-clean"),
+    concat      = require("gulp-concat"),
+    browserSync = require("browser-sync"),
+    cssmin      = require("gulp-cssmin"),
+    filter      = require("gulp-filter"),
+    git         = require("gulp-git"),
+    gulpif      = require("gulp-if"),
+    imagemin    = require("gulp-imagemin"),
+    rename      = require("gulp-rename"),
+    sass        = require("gulp-sass"),
+    shell       = require("gulp-shell"),
+    tagversion  = require("gulp-tag-version"),
+    uglify      = require("gulp-uglify"),
+    ghPages     = require("gulp-gh-pages"),
+    runSequence = require("run-sequence"),
+    glob        = require("glob"),
+    svgmin      = require("gulp-svgmin"),
+    gulpicon    = require("gulpicon/tasks/gulpicon"),
+    sourcemaps  = require("gulp-sourcemaps"),
+    prefix      = require("gulp-autoprefixer"),
+    postcss     = require("gulp-postcss"),
+    replace     = require("gulp-replace"),
+    reporter    = require("postcss-reporter"),
+    stylelint   = require("gulp-stylelint"),
+    gutil       = require("gulp-util");
+    gutil       = require("gulp-util"),
+    pWaitFor    = require("p-wait-for"),
+    pathExists  = require("path-exists");
 
 // Config
-var config = require('./build.config.json');
+var config = require("./build.config.json");
 
 
 // Trigger
@@ -38,7 +39,7 @@ var production;
 
 // Task: Clean:before
 // Description: Removing assets files before running other tasks
-gulp.task('clean:before', function () {
+gulp.task("clean:before", function () {
   return gulp.src(
     config.assets.dest
   )
@@ -48,22 +49,22 @@ gulp.task('clean:before', function () {
 });
 
 // Task: Handle scripts
-gulp.task('scripts', function () {
+gulp.task("scripts", function () {
   return gulp.src(config.scripts.files)
     // unminified for development
     .pipe(sourcemaps.init())
-    .pipe(concat('app.js'))
+    .pipe(concat("app.js"))
     .pipe(sourcemaps.write())
     .pipe(gulp.dest(config.scripts.dest))
-    // also 'production-ready' js file even though we don't use it yet
-    .pipe(rename('app.min.js'))
+    // also "production-ready" js file even though we don"t use it yet
+    .pipe(rename("app.min.js"))
     .pipe(uglify())
     .pipe(gulp.dest(config.scripts.dest))
     .pipe(browserSync.reload({stream:true}));
 });
 
 // Task: Handle fonts
-gulp.task('fonts', function () {
+gulp.task("fonts", function () {
   return gulp.src(config.fonts.files)
     .pipe(gulp.dest(
       config.fonts.dest
@@ -72,7 +73,7 @@ gulp.task('fonts', function () {
 });
 
 // Task: Handle images
-gulp.task('images', function () {
+gulp.task("images", function () {
   return gulp.src(config.images.files)
     .pipe(gulpif(production, imagemin()))
     .pipe(gulp.dest(
@@ -82,15 +83,15 @@ gulp.task('images', function () {
 });
 
 // Task: Handle Sass and CSS
-gulp.task('sass', function () {
+gulp.task("sass", function () {
   return gulp.src(config.scss.files)
     .pipe(sass())
-    .pipe(prefix('last 2 version'))
+    .pipe(prefix("last 2 version"))
     .pipe(gulpif(production, cssmin()))
     .pipe(gulpif(production, rename({
-      suffix: '.min'
+      suffix: ".min"
     })))
-    .pipe(sourcemaps.write('.'))
+    .pipe(sourcemaps.write("."))
     .pipe(gulp.dest(
       config.scss.dest
     ))
@@ -100,7 +101,7 @@ gulp.task('sass', function () {
 // Task: Handle icons
 // We have to do this in a few steps until
 // https://github.com/filamentgroup/gulpicon/issues/1 is resolved
-gulp.task('minifyIcons', function() {
+gulp.task("minifyIcons", function() {
   return gulp.src(config.icons.files)
       .pipe(svgmin())
       .pipe(gulp.dest(config.icons.min));
@@ -110,42 +111,50 @@ gulp.task('minifyIcons', function() {
 var iconFiles = glob.sync("source/assets/icons/svg/*.svg");
 var iconConfig = require("./source/assets/icons/config.js");
 iconConfig.dest = "public/assets/icons/";
-gulp.task('makeIcons', gulpicon(iconFiles, iconConfig));
-gulp.task('waitForIcons', function(callback) {
-  var trigger = iconConfig.dest + 'preview.html';
-  return pWaitFor(() => pathExists(trigger, '1000')).then(() => {
-    console.log('Yay! The icons now exist.');
+gulp.task("makeIcons", gulpicon(iconFiles, iconConfig));
+gulp.task("waitForIcons", function(callback) {
+  var trigger = iconConfig.dest + "preview.html";
+  return pWaitFor(() => pathExists(trigger, "1000")).then(() => {
+    console.log("Yay! The icons now exist.");
   });
 });
-gulp.task('reloadIcons', function() {
-  return gulp.src('', {read: false})
+gulp.task("reloadIcons", function() {
+  return gulp.src("", {read: false})
     .pipe(browserSync.reload({stream:true}));
 });
 
-gulp.task('icons', function (callback) {
-  runSequence('minifyIcons', 'makeIcons', 'waitForIcons', 'reloadIcons', callback);
+gulp.task("icons", function (callback) {
+  runSequence("minifyIcons", "makeIcons", "waitForIcons", "reloadIcons", callback);
 });
 
 // Task: patternlab
 // Description: Build static Pattern Lab files via PHP script
-gulp.task('patternlab', function () {
-  return gulp.src('', {read: false})
+gulp.task("patternlab", function () {
+  return gulp.src("", {read: false})
     .pipe(shell([
-      'php core/console --generate'
+      "php core/console --generate"
     ]))
     .pipe(browserSync.reload({stream:true}));
 });
 
+// Task: PanelInject
+// Description: Let us inject a scss panel into patternlab assets js
+gulp.task("panel-inject", function() {
+  gulp.src("public/index.html")
+    .pipe(replace(/patternlab-viewer\.min\.js\"><\/script>\s+\n/g,'patternlab-viewer.min.js"></script>\n<script>var fileSuffixPattern = ((config.outputFileSuffixes !== undefined) && (config.outputFileSuffixes.rawTemplate !== undefined)) ? config.outputFileSuffixes.rawTemplate : ""; Panels.add({ "id": "sg-panel-scss", "name": "SCSS", "default": false, "templateID": "pl-panel-template-code", "httpRequest": true, "httpRequestReplace": fileSuffixPattern+".scss", "httpRequestCompleted": false, "prismHighlight": true, "language": "markup", "keyCombo": "ctrl+shift+t" });</script>\n'))
+    .pipe(gulp.dest("public"))
+});
+
 // Task: styleguide
 // Description: Copy Styleguide-Folder from core/ to public
-gulp.task('styleguide', function() {
+gulp.task("styleguide", function() {
   return gulp.src(config.patternlab.styleguide.files)
     .pipe(gulp.dest(config.patternlab.styleguide.dest));
 });
 
 // task: BrowserSync
 // Description: Run BrowserSync server with disabled ghost mode
-gulp.task('browser-sync', function() {
+gulp.task("browser-sync", function() {
   browserSync({
     server: {
         baseDir: config.root
@@ -157,121 +166,122 @@ gulp.task('browser-sync', function() {
 
 // Task: Sass Linting
 // Description: lint sass files
-gulp.task('scss-lint', function() {
+gulp.task("scss-lint", function() {
   return gulp.src(config.scss.files)
     .pipe(stylelint({
       reporters: [
-        {formatter: 'string', console: true}
+        {formatter: "string", console: true}
       ]
     }));
 });
 
 // Task: Watch files
-gulp.task('watch', function () {
+gulp.task("watch", function () {
 
   // Watch Pattern Lab files
   gulp.watch(
     config.patternlab.files,
-    ['patternlab']
+    ["patternlab"]
   );
 
   // Watch scripts
   gulp.watch(
     config.scripts.files,
-    ['scripts']
+    ["scripts"]
   );
 
   // Watch images
   gulp.watch(
     config.images.files,
-    ['images']
+    ["images"]
   );
 
   // Watch Sass
   gulp.watch(
     config.scss.files,
-    ['sass']
+    ["sass"]
   );
 
   // Watch icons
   gulp.watch(
     config.icons.files,
-    ['icons']
+    ["icons"]
   );
 
   // Watch fonts
   gulp.watch(
     config.fonts.files,
-    ['fonts']
+    ["fonts"]
   );
 });
 
 // Task: Default
 // Description: Build all stuff of the project once
-gulp.task('default', ['clean:before'], function (callback) {
+gulp.task("default", ["clean:before"], function (callback) {
   production = false;
 
   // We need to re-run sass last to make sure the latest styles.css gets loaded
   runSequence(
-    'icons',
-    ['scripts', 'fonts', 'images', 'sass'],
-    'patternlab',
-    'styleguide',
-    'sass',
+    "icons",
+    ["scripts", "fonts", "images", "sass"],
+    "patternlab",
+    "panel-inject",
+    "styleguide",
+    "sass",
     callback
   );
 });
 
 // Task: Start your production-process
-// Description: Type 'gulp' in the terminal
-gulp.task('serve', function () {
+// Description: Type "gulp" in the terminal
+gulp.task("serve", function () {
   production = false;
 
   runSequence(
-    'default',
-    'browser-sync',
-    'watch'
+    "default",
+    "browser-sync",
+    "watch"
   );
 });
 
 // Task: Publish static content
 // Description: Publish static content using rsync shell command
-gulp.task('publish', function () {
+gulp.task("publish", function () {
   return gulp.src(config.deployment.local.path)
     .pipe(ghPages());
 });
 
 // Task: Deploy to GitHub pages
 // Description: Build the public code and deploy it to GitHub pages
-gulp.task('deploy', function () {
+gulp.task("deploy", function () {
   // make sure to use the gulp from node_modules and not a different version
-  runSequence = require('run-sequence').use(gulp);
+  runSequence = require("run-sequence").use(gulp);
   // run default to build the code and then publish it GitHub pages
-  runSequence('default', 'publish');
+  runSequence("default", "publish");
 });
 
 // Function: Releasing (Bump, Tagging & Deploying)
 // Description: Bump npm versions, create Git tag and push to origin
-gulp.task('tag', function () {
+gulp.task("tag", function () {
   production = true;
 
   return gulp.src(config.versioning.files)
     .pipe(bump({
-      type: gutil.env.env || 'development'
+      type: gutil.env.env || "development"
     }))
-    .pipe(gulp.dest('./'))
-    .pipe(git.commit('Release a ' + gutil.env.env + '-update'))
+    .pipe(gulp.dest("./"))
+    .pipe(git.commit("Release a " + gutil.env.env + "-update"))
 
     // read only one file to get version number
-    .pipe(filter('package.json'))
+    .pipe(filter("package.json"))
 
     // Tag it
     .pipe(tagversion())
 
     // Publish files and tags to endpoint
     .pipe(shell([
-      'git push origin develop',
-      'git push origin --tags'
+      "git push origin develop",
+      "git push origin --tags"
     ]));
 });
 
@@ -279,9 +289,9 @@ gulp.task('tag', function () {
 // Description: Release runs default to build the files,
 // runs tag to tag the release and pushes that to GitHub
 // runs publish to also make sure GitHub pages site is updated
-gulp.task('release', function () {
+gulp.task("release", function () {
   // make sure to use the gulp from node_modules and not a different version
-  runSequence = require('run-sequence').use(gulp);
+  runSequence = require("run-sequence").use(gulp);
   // run default to build the code, next tag to cut a tag, then publish to deploy to GitHub pages
-  runSequence('default', 'tag', 'publish');
+  runSequence("default", "tag", "publish");
 });

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "glob": "^7.1.1",
+    "gulp-replace": "^0.5.4",
     "gulp-svgmin": "^1.2.3",
     "gulpicon": "^1.2.1",
     "run-sequence": "^1.2.2"


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)
**Jira Ticket**

- [EWL-3093: Get CSS in Tab](https://issues.ama-assn.org/browse/EWL-3093)


## Description

Grossly misuse Gulp to inject some panel code into patternlab source files instead of having to fork from their repos or patch.

## To Test

- [ ] Navigate to `styleguide/` and run `npm install`
- [ ] run `gulp serve`
- [ ] Click upper right Settings gear > Show Pattern Info
- [ ] See that scss panel exists
- [ ] Go to a pattern with scss (so not the intro) and see that the scss is available in the pattern


## Relevant Screenshots/GIFs

![screen shot 2017-06-16 at 10 53 08 am](https://user-images.githubusercontent.com/28711067/27245098-4bc2200a-52af-11e7-9027-34f64377b336.png)

## Remaining Tasks

Should probably add a try/catch in the php so the log doesn't show warning when no scss file exists.


## Additional Notes

We should decide if we like this approach and if we want to try to add other panels, show css instead of scss, and/or if we require styling to the markup (not sure yet how easily that might be accomplished).
