### PR TITLE
[EWL-3573] : creates a partner logo card row

### DIFF
--- a/styleguide/source/_patterns/00-atoms/04-images/00-logo.twig
+++ b/styleguide/source/_patterns/00-atoms/04-images/00-logo.twig
@@ -1,1 +1,1 @@
-<a href="{{ link.pages-homepage }}" class="logo logo-outer"><img src="../../assets/images/logo.svg" class="logo" alt="American Medical Association" /></a>
+<a href="{{ link|default ('link.pages-homepage') }}" class="logo logo-outer {{ class }}"><img src="{{ image|default('../../assets/images/logo.svg') }}" class="logo" alt="{{ alt|default('American Medical Association') }}" /></a>

--- a/styleguide/source/_patterns/02-organisms/05-ec/02-ec-partner-row/_ec-partner-row.scss
+++ b/styleguide/source/_patterns/02-organisms/05-ec/02-ec-partner-row/_ec-partner-row.scss
@@ -1,0 +1,24 @@
+.ec-partner-row {
+	.ec-partner-card {
+		border-right: 0.5rem solid transparent;
+
+		@include grid__unit--cols(6);
+		&:nth-child(n+5) {
+			display: none;
+		}
+
+		@include breakpoint($bp-small){
+			@include grid__unit--cols(4);
+			&:nth-child(n+4) {
+				display: none;
+			}
+		}
+
+		@include breakpoint($bp-med){
+			@include grid__unit--cols(2);
+			&:nth-child(n+4) {
+				display: block;
+			}
+		}
+	}
+}

--- a/styleguide/source/_patterns/02-organisms/05-ec/02-ec-partner-row/_ec-partner-row.scss
+++ b/styleguide/source/_patterns/02-organisms/05-ec/02-ec-partner-row/_ec-partner-row.scss
@@ -1,6 +1,7 @@
 .ec-partner-row {
 	.ec-partner-card {
 		border-right: 0.5rem solid transparent;
+		list-style-type: none;
 
 		@include grid__unit--cols(6);
 		&:nth-child(n+5) {

--- a/styleguide/source/_patterns/02-organisms/05-ec/02-ec-partner-row/ec-partner-row.md
+++ b/styleguide/source/_patterns/02-organisms/05-ec/02-ec-partner-row/ec-partner-row.md
@@ -1,0 +1,7 @@
+---
+el: ".ec-partner-row"
+title: "EC Partner Row"
+---
+This component is a row of linked logo images on the EC Marketing page. There can be up to 6 cards in a row on the desktop layout, up to 3 cards in a row on tablet, and up to 2 cards in a row on mobile with a max of 2 rows. Each logo on desktop has a max width of 2 columns.
+
+[EWL-3573](https://issues.ama-assn.org/browse/EWL-3573)

--- a/styleguide/source/_patterns/02-organisms/05-ec/02-ec-partner-row/ec-partner-row.twig
+++ b/styleguide/source/_patterns/02-organisms/05-ec/02-ec-partner-row/ec-partner-row.twig
@@ -1,8 +1,8 @@
-<div class="ec-partner-row layout">
-  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
-  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
-  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
-  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
-  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
-  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
-</div>
+<ul class="ec-partner-row layout">
+	<li class='ec-partner-card'>{% include 'atoms-logo' with {'link': '#', 'image': 'http://via.placeholder.com/350x150', 'alt': 'partner-logo'} %}</li>
+	<li class='ec-partner-card'>{% include 'atoms-logo' with {'link': '#', 'image': 'http://via.placeholder.com/350x150', 'alt': 'partner-logo'} %}</li>
+	<li class='ec-partner-card'>{% include 'atoms-logo' with {'link': '#', 'image': 'http://via.placeholder.com/350x150', 'alt': 'partner-logo'} %}</li>
+	<li class='ec-partner-card'>{% include 'atoms-logo' with {'link': '#', 'image': 'http://via.placeholder.com/350x150', 'alt': 'partner-logo'} %}</li>
+	<li class='ec-partner-card'>{% include 'atoms-logo' with {'link': '#', 'image': 'http://via.placeholder.com/350x150', 'alt': 'partner-logo'} %}</li>
+	<li class='ec-partner-card'>{% include 'atoms-logo' with {'link': '#', 'image': 'http://via.placeholder.com/350x150', 'alt': 'partner-logo'} %}</li>
+</ul>

--- a/styleguide/source/_patterns/02-organisms/05-ec/02-ec-partner-row/ec-partner-row.twig
+++ b/styleguide/source/_patterns/02-organisms/05-ec/02-ec-partner-row/ec-partner-row.twig
@@ -1,0 +1,8 @@
+<div class="ec-partner-row layout">
+  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
+  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
+  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
+  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
+  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
+  <a class="ec-partner-card" href="#"><img src="http://via.placeholder.com/350x150"></a>
+</div>

--- a/styleguide/source/assets/css/style.scss
+++ b/styleguide/source/assets/css/style.scss
@@ -166,6 +166,7 @@ So feel free to use any of these approaches. Or don't. It's totally up to you.
 @import "../../_patterns/02-organisms/03-sections/08-multi-step-form/multi-step-form";
 @import "../../_patterns/02-organisms/03-sections/09-best-match-dropdown/best-match-dropdown";
 @import "../../_patterns/02-organisms/05-ec/01-ec-search-bar/ec-search-bar";
+@import "../../_patterns/02-organisms/05-ec/02-ec-partner-row/ec-partner-row";
 @import "../../_patterns/01-molecules/01-layouts/00-layout-one-up/layout-one-up";
 @import "../../_patterns/01-molecules/01-layouts/01-layout-two-up/layout-two-up";
 @import "../../_patterns/01-molecules/01-layouts/02-layout-two-up-heavy-left/layout-two-up-heavy-left";


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWL-3573: EC | Design Partner Logo component](https://issues.ama-assn.org/browse/EWL-3573)


## Description

Created a row of linked images per wireframes


## To Test

- [x] Go to Organisms > EC > EC Partner Row
- [x] See that there are linked placeholder images in a row that cna hold up to 6 images across in desktop and that are 2 cols in width


## Relevant Screenshots/GIFs

None.


## Remaining Tasks

Could make molecules for the logo images themselves, but that seemed unnecessary given how simple they are.


## Additional Notes

Anything more to add?
