### PR TITLE
Ewl 3093 css tab patch

### DIFF
--- a/styleguide/composer.json
+++ b/styleguide/composer.json
@@ -29,7 +29,8 @@
 		"php": ">=5.4",
 		"pattern-lab/core": "dev-dev#c976fa4cbffac7a67c41df43f47899d09a965a49",
 		"pattern-lab/patternengine-twig": "dev-dev",
-		"pattern-lab/styleguidekit-twig-default": "dev-dev"
+		"pattern-lab/styleguidekit-twig-default": "dev-dev",
+		"cweagans/composer-patches": "dev-master"
 	},
 	"repository": {
 		"type": "vcs",
@@ -63,6 +64,11 @@
 				"pattern-lab/starterkit-twig-base",
 				"pattern-lab/starterkit-twig-demo"
 			]
-		}
+		},
+		"patches": {
+	      "pattern-lab/core": {
+	        "Add scss files to builder": "patches/core-builder-scss-files.patch"
+	      }
+	    }
 	}
 }

--- a/styleguide/composer.json
+++ b/styleguide/composer.json
@@ -68,6 +68,9 @@
 		"patches": {
 	      "pattern-lab/core": {
 	        "Add scss files to builder": "patches/core-builder-scss-files.patch"
+	      },
+	      "pattern-lab/styleguidekit-assets-default": {
+	        "Add scss panel to viewer": "patches/styleguidekit-index-scss-panel.patch"
 	      }
 	    }
 	}

--- a/styleguide/composer.lock
+++ b/styleguide/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "13c6bb01cca22ad46a2367a4f7b06b56",
+    "content-hash": "fb900c21e4d640b09640d249418027fe",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -67,6 +67,50 @@
                 "zip"
             ],
             "time": "2016-02-15T22:46:40+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "b3036f23b73570ab5d869e345277786c8eb248a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/b3036f23b73570ab5d869e345277786c8eb248a9",
+                "reference": "b3036f23b73570ab5d869e345277786c8eb248a9",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "time": "2017-03-19 18:18:52"
         },
         {
             "name": "doctrine/collections",
@@ -884,7 +928,8 @@
     "stability-flags": {
         "pattern-lab/core": 20,
         "pattern-lab/patternengine-twig": 20,
-        "pattern-lab/styleguidekit-twig-default": 20
+        "pattern-lab/styleguidekit-twig-default": 20,
+        "cweagans/composer-patches": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/styleguide/patches/core-builder-scss-files.patch
+++ b/styleguide/patches/core-builder-scss-files.patch
@@ -1,0 +1,28 @@
+--- vendor/pattern-lab/core/src/PatternLab/Builder.php	2017-06-19 13:16:11.000000000 -0500
++++ vendor/pattern-lab/core/src/PatternLab/Builder-patch.php	2017-06-20 11:31:20.000000000 -0500
+@@ -216,11 +216,15 @@
+ 				
+ 				$path          = $patternStoreData["pathDash"];
+ 				$pathName      = (isset($patternStoreData["pseudo"])) ? $patternStoreData["pathOrig"] : $patternStoreData["pathName"];
++				$pathParts = explode("/",$pathName);
++				array_pop($pathParts);
++				$scssPathName  = implode("/",$pathParts)."/_".$patternStoreData["name"];
+ 
+ 				// modify the pattern mark-up
+ 				$markup        = $patternStoreData["code"];
+ 				$markupFull    = $patternStoreData["header"].$markup.$patternStoreData["footer"];
+ 				$markupEngine  = file_get_contents($patternSourceDir."/".$pathName.".".$patternExtension);
++				$scss 		   = @file_get_contents($patternSourceDir."/".$scssPathName.".scss")
+ 				
+ 				// if the pattern directory doesn't exist create it
+ 				if (!is_dir($patternPublicDir."/".$path)) {
+@@ -232,6 +236,9 @@
+ 				if (!$exportFiles) {
+ 					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixMarkupOnly.".html",$markup);
+ 					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRaw.".".$patternExtension,$markupEngine);
++					if ($scss) {
++						file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRaw.".scss",$scss)
++					}
+ 				}
+ 				
+ 			}

--- a/styleguide/patches/core-builder-scss-files.patch
+++ b/styleguide/patches/core-builder-scss-files.patch
@@ -1,6 +1,6 @@
---- src/PatternLab/Builder.php	2017-06-20 16:50:36.000000000 -0500
-+++ src/PatternLab/Builder-new.php	2017-06-20 16:52:29.000000000 -0500
-@@ -216,11 +216,15 @@
+--- src/PatternLab/Builder.php	2017-06-22 12:02:11.000000000 -0500
++++ src/PatternLab/Builder-new.php	2017-06-22 12:03:09.000000000 -0500
+@@ -216,11 +216,18 @@
  				
  				$path          = $patternStoreData["pathDash"];
  				$pathName      = (isset($patternStoreData["pseudo"])) ? $patternStoreData["pathOrig"] : $patternStoreData["pathName"];
@@ -14,10 +14,13 @@
  				$markupFull    = $patternStoreData["header"].$markup.$patternStoreData["footer"];
  				$markupEngine  = file_get_contents($patternSourceDir."/".$pathName.".".$patternExtension);
 +				$scss 		   = @file_get_contents($patternSourceDir."/".$scssPathName.".scss");
++				if ($scss === false) {
++					$scss = "No scss available for this pattern.";
++				}
  				
  				// if the pattern directory doesn't exist create it
  				if (!is_dir($patternPublicDir."/".$path)) {
-@@ -232,6 +236,7 @@
+@@ -232,6 +239,7 @@
  				if (!$exportFiles) {
  					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixMarkupOnly.".html",$markup);
  					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRaw.".".$patternExtension,$markupEngine);

--- a/styleguide/patches/core-builder-scss-files.patch
+++ b/styleguide/patches/core-builder-scss-files.patch
@@ -1,18 +1,19 @@
---- vendor/pattern-lab/core/src/PatternLab/Builder.php	2017-06-19 13:16:11.000000000 -0500
-+++ vendor/pattern-lab/core/src/PatternLab/Builder-patch.php	2017-06-20 11:31:20.000000000 -0500
+--- src/PatternLab/Builder.php	2017-06-20 16:08:52.000000000 -0500
++++ src/PatternLab/Builder-new.php	2017-06-20 16:14:16.000000000 -0500
 @@ -216,11 +216,15 @@
  				
  				$path          = $patternStoreData["pathDash"];
  				$pathName      = (isset($patternStoreData["pseudo"])) ? $patternStoreData["pathOrig"] : $patternStoreData["pathName"];
+-				
 +				$pathParts = explode("/",$pathName);
 +				array_pop($pathParts);
 +				$scssPathName  = implode("/",$pathParts)."/_".$patternStoreData["name"];
- 
++
  				// modify the pattern mark-up
  				$markup        = $patternStoreData["code"];
  				$markupFull    = $patternStoreData["header"].$markup.$patternStoreData["footer"];
  				$markupEngine  = file_get_contents($patternSourceDir."/".$pathName.".".$patternExtension);
-+				$scss 		   = @file_get_contents($patternSourceDir."/".$scssPathName.".scss")
++				$scss 		   = @file_get_contents($patternSourceDir."/".$scssPathName.".scss");
  				
  				// if the pattern directory doesn't exist create it
  				if (!is_dir($patternPublicDir."/".$path)) {

--- a/styleguide/patches/core-builder-scss-files.patch
+++ b/styleguide/patches/core-builder-scss-files.patch
@@ -1,5 +1,5 @@
---- src/PatternLab/Builder.php	2017-06-20 16:08:52.000000000 -0500
-+++ src/PatternLab/Builder-new.php	2017-06-20 16:14:16.000000000 -0500
+--- src/PatternLab/Builder.php	2017-06-20 16:50:36.000000000 -0500
++++ src/PatternLab/Builder-new.php	2017-06-20 16:52:29.000000000 -0500
 @@ -216,11 +216,15 @@
  				
  				$path          = $patternStoreData["pathDash"];
@@ -17,13 +17,11 @@
  				
  				// if the pattern directory doesn't exist create it
  				if (!is_dir($patternPublicDir."/".$path)) {
-@@ -232,6 +236,9 @@
+@@ -232,6 +236,7 @@
  				if (!$exportFiles) {
  					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixMarkupOnly.".html",$markup);
  					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRaw.".".$patternExtension,$markupEngine);
-+					if ($scss) {
-+						file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRaw.".scss",$scss)
-+					}
++					file_put_contents($patternPublicDir."/".$path."/".$path.$suffixRaw.".scss",$scss);
  				}
  				
  			}

--- a/styleguide/patches/styleguidekit-index-scss-panel.patch
+++ b/styleguide/patches/styleguidekit-index-scss-panel.patch
@@ -1,0 +1,14 @@
+--- dist/index.html	2017-06-20 16:38:22.000000000 -0500
++++ dist/index-new.html	2017-06-20 16:41:01.000000000 -0500
+@@ -274,6 +274,11 @@
+     
+     <!-- load the pattern lab viewer js -->
+     <script src="styleguide/js/patternlab-viewer.min.js"></script>
++
++    <script>
++      var fileSuffixPattern = ((config.outputFileSuffixes !== undefined) && (config.outputFileSuffixes.rawTemplate !== undefined)) ? config.outputFileSuffixes.rawTemplate : "";
++      Panels.add({ "id": "sg-panel-scss", "name": "SCSS", "default": false, "templateID": "pl-panel-template-code", "httpRequest": true, "httpRequestReplace": fileSuffixPattern+".scss", "httpRequestCompleted": false, "prismHighlight": true, "language": "markup", "keyCombo": "ctrl+shift+t" });
++    </script>
+     
+   </body>
+ </html>


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)
**Jira Ticket**

- [EWL-3093: Get CSS in Tab](https://issues.ama-assn.org/browse/EWL-3093)

Related PR:
- [https://github.com/AmericanMedicalAssociation/AMA-style-guide/pull/144](https://github.com/AmericanMedicalAssociation/AMA-style-guide/pull/144)

## Description

Uses patches instead of gulp to achieve scss panel injection.

## To Test

- [ ] You should probably delete your current `vendor/pattern-lab` folder so that it will force reinstallation and guarantee the patches are applied
- [ ] Navigate to `styleguide/` and run `composer install`
- [ ] run `gulp serve` or `./node_modules/.bin/gulp serve`
- [ ] Click upper right Settings gear > Show Pattern Info
- [ ] See that scss panel exists
- [ ] Go to a pattern with scss (so not the intro) and see that the scss is available in the pattern


## Relevant Screenshots/GIFs

![screen shot 2017-06-16 at 10 53 08 am](https://user-images.githubusercontent.com/28711067/27245098-4bc2200a-52af-11e7-9027-34f64377b336.png)

## Remaining Tasks

There are countless improvements that could be made, but probably separate tickets should be made for those


## Additional Notes

This is a somewhat nicer approach than the gulp, but composer is less predictable about when it recognizes patch updates when you run `composer install`. You sometimes have to purge the libraries to force it to install and patch.

**PR #144 should be closed out if/when this is merged.**
