### PR TITLE
adds styles that remove the default <select> element drown down arrow…

### DIFF
--- a/styleguide/source/assets/css/scss/base/_forms.scss
+++ b/styleguide/source/assets/css/scss/base/_forms.scss
@@ -110,6 +110,9 @@ select {
   background-position: calc(100% - 8px) 52%;
   background-repeat: no-repeat;
   padding-right: 30px;
+  -moz-appearance: none; /*removes default dropdown arrow in Firefox*/
+  text-indent: 0.01px; /*removes default dropdown arrow in Firefox*/
+  text-overflow: ''; /*removes default dropdown arrow in Firefox*/
 }
 
 // Placeholder text styles


### PR DESCRIPTION
… in firefox

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.

**Github Issue**
- [Issue 155:Task: Default dropdown style for element in firefox needs to be removed Description The default dropdown style for element in firefox needs to be removed.](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/155)

**Jira Ticket**
N/A

## Description

I added these lines to the select element's styles in the forms.scss file:

```
  -moz-appearance: none; /*removes default dropdown arrow in Firefox*/
  text-indent: 0.01px; /*removes default dropdown arrow in Firefox*/
  text-overflow: ''; /*removes default dropdown arrow in Firefox*/
```

## To Test

- Open a file that has a `<select>` element in firefox to see the issue. You can see it in the styleguide currently: https://americanmedicalassociation.github.io/AMA-style-guide/?p=molecules-input-select (open this file in firefox and you'll see the default dropdown arrow along with the icon that the styleguide calls)


## Relevant Screenshots/GIFs

The issue:
<img width="475" alt="screen shot 2017-06-26 at 2 08 25 pm" src="https://user-images.githubusercontent.com/11623187/27557294-af8b745c-5a7e-11e7-8fd0-576b0200e29c.png">

After the issue has been fixed:
<img width="479" alt="screen shot 2017-06-26 at 2 42 55 pm" src="https://user-images.githubusercontent.com/11623187/27557297-b1588f68-5a7e-11e7-8526-5ef2ca193fc7.png">



## Remaining Tasks

No remaining tasks.


## Additional Notes

Nope. This is my first PR to the styleguide, let me know if I did anything wrong :)