### PR TITLE
[EWL-3812] : changes pattern lab version to 2.7.0 stable, creates pat…

### DIFF
--- a/styleguide/composer.json
+++ b/styleguide/composer.json
@@ -27,9 +27,10 @@
 	},
 	"require": {
 		"php": ">=5.4",
-		"pattern-lab/core": "dev-dev#c976fa4cbffac7a67c41df43f47899d09a965a49",
-		"pattern-lab/patternengine-twig": "dev-dev",
-		"pattern-lab/styleguidekit-twig-default": "dev-dev",
+		"pattern-lab/core": "^2.7.0",
+		"pattern-lab/patternengine-twig": "dev-master",
+		"pattern-lab/styleguidekit-twig-default": "dev-master",
+		"pattern-lab/plugin-data-inheritance": "dev-master",
 		"cweagans/composer-patches": "dev-master"
 	},
 	"repository": {
@@ -66,7 +67,8 @@
 			]
 		},
 		"patches": {
-	      "pattern-lab/core": {
+			"pattern-lab/core": {
+	        "Add commit c976fa4 from dev": "patches/core-c976fa4.patch",
 	        "Add scss files to builder": "patches/core-builder-scss-files.patch"
 	      },
 	      "pattern-lab/styleguidekit-assets-default": {

--- a/styleguide/composer.lock
+++ b/styleguide/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5789eb97162e2f6c58887282cd908a7d",
+    "content-hash": "4f1d43a6735fddb1f2914b142c7bf816",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -1000,8 +1000,8 @@
     "stability-flags": {
         "pattern-lab/patternengine-twig": 20,
         "pattern-lab/styleguidekit-twig-default": 20,
-        "cweagans/composer-patches": 20,
-        "pattern-lab/plugin-data-inheritance": 20
+        "pattern-lab/plugin-data-inheritance": 20,
+        "cweagans/composer-patches": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/styleguide/composer.lock
+++ b/styleguide/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb900c21e4d640b09640d249418027fe",
+    "content-hash": "5789eb97162e2f6c58887282cd908a7d",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -74,12 +74,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweagans/composer-patches.git",
-                "reference": "b3036f23b73570ab5d869e345277786c8eb248a9"
+                "reference": "f296498b27b7bd36030572d314af80272fe19dd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/b3036f23b73570ab5d869e345277786c8eb248a9",
-                "reference": "b3036f23b73570ab5d869e345277786c8eb248a9",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/f296498b27b7bd36030572d314af80272fe19dd7",
+                "reference": "f296498b27b7bd36030572d314af80272fe19dd7",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 }
             ],
             "description": "Provides a way to patch Composer packages.",
-            "time": "2017-03-19 18:18:52"
+            "time": "2017-07-17 14:24:05"
         },
         {
             "name": "doctrine/collections",
@@ -283,16 +283,16 @@
         },
         {
             "name": "pattern-lab/core",
-            "version": "dev-dev",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pattern-lab/patternlab-php-core.git",
-                "reference": "c976fa4cbffac7a67c41df43f47899d09a965a49"
+                "reference": "e1c0509f06bf959b242c5807c2c624833693c7ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pattern-lab/patternlab-php-core/zipball/c976fa4cbffac7a67c41df43f47899d09a965a49",
-                "reference": "c976fa4cbffac7a67c41df43f47899d09a965a49",
+                "url": "https://api.github.com/repos/pattern-lab/patternlab-php-core/zipball/e1c0509f06bf959b242c5807c2c624833693c7ee",
+                "reference": "e1c0509f06bf959b242c5807c2c624833693c7ee",
                 "shasum": ""
             },
             "require": {
@@ -309,6 +309,12 @@
                 "symfony/yaml": "^3.0"
             },
             "type": "library",
+            "extra": {
+                "patches_applied": {
+                    "Add commit c976fa4 from dev": "patches/core-c976fa4.patch",
+                    "Add scss files to builder": "patches/core-builder-scss-files.patch"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "PatternLab": "src/"
@@ -340,24 +346,24 @@
                 "style guide",
                 "styleguide"
             ],
-            "time": "2016-07-28 21:12:01"
+            "time": "2016-07-22T03:00:05+00:00"
         },
         {
             "name": "pattern-lab/patternengine-twig",
-            "version": "dev-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pattern-lab/patternengine-php-twig.git",
-                "reference": "4490358bc354a4201f00982fedda641aa507e94a"
+                "reference": "65324c72d2fb3a10cb25bbd65ce08a89fefc5896"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pattern-lab/patternengine-php-twig/zipball/4490358bc354a4201f00982fedda641aa507e94a",
-                "reference": "4490358bc354a4201f00982fedda641aa507e94a",
+                "url": "https://api.github.com/repos/pattern-lab/patternengine-php-twig/zipball/65324c72d2fb3a10cb25bbd65ce08a89fefc5896",
+                "reference": "65324c72d2fb3a10cb25bbd65ce08a89fefc5896",
                 "shasum": ""
             },
             "require": {
-                "pattern-lab/core": "dev-dev",
+                "pattern-lab/core": "^2.0.0",
                 "twig/twig": "~1.0"
             },
             "type": "patternlab-patternengine",
@@ -403,20 +409,77 @@
                 "pattern lab",
                 "twig"
             ],
-            "time": "2016-05-19 03:09:58"
+            "time": "2016-10-12 21:51:54"
         },
         {
-            "name": "pattern-lab/styleguidekit-assets-default",
-            "version": "dev-dev",
+            "name": "pattern-lab/plugin-data-inheritance",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/pattern-lab/styleguidekit-assets-default.git",
-                "reference": "f49ad46ded4d01976b4784dfef83fbc47ebfcbe8"
+                "url": "https://github.com/pattern-lab/plugin-php-data-inheritance.git",
+                "reference": "c985247aae0b46a7131d12678f118c25e742cd02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pattern-lab/styleguidekit-assets-default/zipball/f49ad46ded4d01976b4784dfef83fbc47ebfcbe8",
-                "reference": "f49ad46ded4d01976b4784dfef83fbc47ebfcbe8",
+                "url": "https://api.github.com/repos/pattern-lab/plugin-php-data-inheritance/zipball/c985247aae0b46a7131d12678f118c25e742cd02",
+                "reference": "c985247aae0b46a7131d12678f118c25e742cd02",
+                "shasum": ""
+            },
+            "require": {
+                "pattern-lab/core": "^2.5.0",
+                "php": ">=5.4"
+            },
+            "type": "patternlab-plugin",
+            "extra": {
+                "patternlab": {
+                    "config": {
+                        "plugins": {
+                            "dataInheritance": {
+                                "enabled": true
+                            }
+                        }
+                    }
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PatternLab\\DataInheritance": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dave Olsen",
+                    "email": "dmolsen@gmail.com",
+                    "homepage": "http://dmolsen.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Data inheritance based on pattern lineage for Pattern Lab.",
+            "homepage": "http://patternlab.io",
+            "keywords": [
+                "data",
+                "inheritance",
+                "lineage",
+                "pattern lab"
+            ],
+            "time": "2016-07-03 00:17:04"
+        },
+        {
+            "name": "pattern-lab/styleguidekit-assets-default",
+            "version": "v3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pattern-lab/styleguidekit-assets-default.git",
+                "reference": "51f2fc2aa40aea8efb19f406eef8d81466ec932f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pattern-lab/styleguidekit-assets-default/zipball/51f2fc2aa40aea8efb19f406eef8d81466ec932f",
+                "reference": "51f2fc2aa40aea8efb19f406eef8d81466ec932f",
                 "shasum": ""
             },
             "type": "patternlab-styleguidekit",
@@ -436,6 +499,9 @@
                             "hay"
                         ]
                     }
+                },
+                "patches_applied": {
+                    "Add scss panel to viewer": "patches/styleguidekit-index-scss-panel.patch"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -462,24 +528,24 @@
                 "pattern lab",
                 "styleguide"
             ],
-            "time": "2016-12-22 15:56:00"
+            "time": "2017-05-16T13:46:25+00:00"
         },
         {
             "name": "pattern-lab/styleguidekit-twig-default",
-            "version": "dev-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pattern-lab/styleguidekit-twig-default.git",
-                "reference": "b7b56ef93aaf5b2b746a3cba4fbf4b5b86ea6309"
+                "reference": "7b38bfe2fb60cde3850cfe8f4f948cdc206d7188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pattern-lab/styleguidekit-twig-default/zipball/b7b56ef93aaf5b2b746a3cba4fbf4b5b86ea6309",
-                "reference": "b7b56ef93aaf5b2b746a3cba4fbf4b5b86ea6309",
+                "url": "https://api.github.com/repos/pattern-lab/styleguidekit-twig-default/zipball/7b38bfe2fb60cde3850cfe8f4f948cdc206d7188",
+                "reference": "7b38bfe2fb60cde3850cfe8f4f948cdc206d7188",
                 "shasum": ""
             },
             "require": {
-                "pattern-lab/styleguidekit-assets-default": "dev-dev"
+                "pattern-lab/styleguidekit-assets-default": "^3.0.0"
             },
             "type": "patternlab-styleguidekit",
             "notification-url": "https://packagist.org/downloads/",
@@ -506,24 +572,27 @@
                 "styleguide",
                 "twig"
             ],
-            "time": "2016-07-04 00:47:12"
+            "time": "2016-07-04 01:24:27"
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.5.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "19495c181d6d53a0a13414154e52817e3b504189"
+                "reference": "50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/19495c181d6d53a0a13414154e52817e3b504189",
-                "reference": "19495c181d6d53a0a13414154e52817e3b504189",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77",
+                "reference": "50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5"
             },
             "bin": [
                 "bin/jsonlint"
@@ -552,7 +621,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2016-11-14T17:59:58+00:00"
+            "time": "2017-06-18T15:11:04+00:00"
         },
         {
             "name": "shudrum/array-finder",
@@ -596,16 +665,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "dev-master",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "b366aa1e03bcfd4b8494087ca44f0afab3624c8d"
+                "reference": "db08b1b2f9adb5d59a5e838d1577e73c418e05ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b366aa1e03bcfd4b8494087ca44f0afab3624c8d",
-                "reference": "b366aa1e03bcfd4b8494087ca44f0afab3624c8d",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/db08b1b2f9adb5d59a5e838d1577e73c418e05ed",
+                "reference": "db08b1b2f9adb5d59a5e838d1577e73c418e05ed",
                 "shasum": ""
             },
             "require": {
@@ -616,10 +685,10 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0",
-                "symfony/dependency-injection": "~3.3",
-                "symfony/expression-language": "~2.8|~3.0",
-                "symfony/stopwatch": "~2.8|~3.0"
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/stopwatch": "~2.8|~3.0|~4.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -628,7 +697,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -655,20 +724,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-28 02:18:26"
+            "time": "2017-06-12 16:03:21"
         },
         {
             "name": "symfony/filesystem",
-            "version": "dev-master",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "5755830b51f2c2f4d9e0b5957b26436f3b507dce"
+                "reference": "353cb00e1fb1342b6e30a6c84e4b301568e58b9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/5755830b51f2c2f4d9e0b5957b26436f3b507dce",
-                "reference": "5755830b51f2c2f4d9e0b5957b26436f3b507dce",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/353cb00e1fb1342b6e30a6c84e4b301568e58b9f",
+                "reference": "353cb00e1fb1342b6e30a6c84e4b301568e58b9f",
                 "shasum": ""
             },
             "require": {
@@ -677,7 +746,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -704,20 +773,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-18 17:35:19"
+            "time": "2017-07-11 07:19:17"
         },
         {
             "name": "symfony/finder",
-            "version": "dev-master",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "1558dea3daea8ddca57ef2c95745f863ce4b2a1e"
+                "reference": "295fa37f13dbc4bba200680d2f4ae2c4a1f77709"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/1558dea3daea8ddca57ef2c95745f863ce4b2a1e",
-                "reference": "1558dea3daea8ddca57ef2c95745f863ce4b2a1e",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/295fa37f13dbc4bba200680d2f4ae2c4a1f77709",
+                "reference": "295fa37f13dbc4bba200680d2f4ae2c4a1f77709",
                 "shasum": ""
             },
             "require": {
@@ -726,7 +795,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -753,20 +822,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21 10:07:34"
+            "time": "2017-06-01 21:02:15"
         },
         {
             "name": "symfony/process",
-            "version": "dev-master",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "b9d0d00d5fee4f27e2a0cc2917a683ca03d4b24c"
+                "reference": "aeea12fe8abbf2f6ccb917c0037a7664d0e20b51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/b9d0d00d5fee4f27e2a0cc2917a683ca03d4b24c",
-                "reference": "b9d0d00d5fee4f27e2a0cc2917a683ca03d4b24c",
+                "url": "https://api.github.com/repos/symfony/process/zipball/aeea12fe8abbf2f6ccb917c0037a7664d0e20b51",
+                "reference": "aeea12fe8abbf2f6ccb917c0037a7664d0e20b51",
                 "shasum": ""
             },
             "require": {
@@ -775,7 +844,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -802,27 +871,27 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-04 12:23:47"
+            "time": "2017-07-15 08:52:56"
         },
         {
             "name": "symfony/yaml",
-            "version": "dev-master",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "902dfb757bbeab73e75258685b3661f92bbe087d"
+                "reference": "8ccc03269a0e2a248c0daff5ad20050388cc07c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/902dfb757bbeab73e75258685b3661f92bbe087d",
-                "reference": "902dfb757bbeab73e75258685b3661f92bbe087d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/8ccc03269a0e2a248c0daff5ad20050388cc07c4",
+                "reference": "8ccc03269a0e2a248c0daff5ad20050388cc07c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
             "require-dev": {
-                "symfony/console": "~2.8|~3.0"
+                "symfony/console": "~2.8|~3.0|~4.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -830,7 +899,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -857,7 +926,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-01 22:36:19"
+            "time": "2017-07-26 06:46:38"
         },
         {
             "name": "twig/twig",
@@ -865,31 +934,34 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "27d7ea9675aa312d48f382f3c71c10bebce768a9"
+                "reference": "6e17134b1a70f58a761d4036fc2d559303b80bf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/27d7ea9675aa312d48f382f3c71c10bebce768a9",
-                "reference": "27d7ea9675aa312d48f382f3c71c10bebce768a9",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/6e17134b1a70f58a761d4036fc2d559303b80bf1",
+                "reference": "6e17134b1a70f58a761d4036fc2d559303b80bf1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.7"
+                "php": ">=5.3.3"
             },
             "require-dev": {
                 "psr/container": "^1.0",
                 "symfony/debug": "~2.7",
-                "symfony/phpunit-bridge": "~3.2"
+                "symfony/phpunit-bridge": "~3.3@dev"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.32-dev"
+                    "dev-master": "1.34-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
                     "Twig_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -919,17 +991,17 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-02-27 00:07:56"
+            "time": "2017-07-22 07:30:43"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "pattern-lab/core": 20,
         "pattern-lab/patternengine-twig": 20,
         "pattern-lab/styleguidekit-twig-default": 20,
-        "cweagans/composer-patches": 20
+        "cweagans/composer-patches": 20,
+        "pattern-lab/plugin-data-inheritance": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/styleguide/config/config.yml
+++ b/styleguide/config/config.yml
@@ -38,3 +38,6 @@ twigFilterExt: filter.php
 twigFunctionExt: function.php
 twigTagExt: tag.php
 twigTestExt: test.php
+plugins:
+    dataInheritance:
+        enabled: true

--- a/styleguide/config/listeners.json
+++ b/styleguide/config/listeners.json
@@ -1,1 +1,1 @@
-{ "listeners": [ ] }
+{"listeners":["\\PatternLab\\DataInheritance\\PatternLabListener"]}

--- a/styleguide/patches/core-c976fa4.patch
+++ b/styleguide/patches/core-c976fa4.patch
@@ -1,0 +1,21 @@
+*** src/PatternLab/Builder.php	2016-07-21 22:00:05.000000000 -0500
+--- src/PatternLab/Builder-new.php	2017-07-26 14:06:55.000000000 -0500
+***************
+*** 391,398 ****
+  					$patternData["patternPartial"] = "viewall-".$patternStoreData["nameDash"]."-all";
+  					
+  					// add the pattern lab specific mark-up
+! 					$partials["patternLabHead"] = $stringLoader->render(array("string" => $htmlHead, "data" => array("cacheBuster" => $partials["cacheBuster"])));
+! 					$partials["patternLabFoot"] = $stringLoader->render(array("string" => $htmlFoot, "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
+  					
+  					// render the parts and join them
+  					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $globalData));
+--- 391,398 ----
+  					$patternData["patternPartial"] = "viewall-".$patternStoreData["nameDash"]."-all";
+  					
+  					// add the pattern lab specific mark-up
+! 					$globalData["patternLabHead"] = $stringLoader->render(array("string" => $htmlHead, "data" => array("cacheBuster" => $partials["cacheBuster"])));
+! 					$globalData["patternLabFoot"] = $stringLoader->render(array("string" => $htmlFoot, "data" => array("cacheBuster" => $partials["cacheBuster"], "patternData" => json_encode($patternData))));
+  					
+  					// render the parts and join them
+  					$header      = $patternLoader->render(array("pattern" => $patternHead, "data" => $globalData));


### PR DESCRIPTION
…ch file for GlobalData fix, installs data-inheritance plugin

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)
**Jira Ticket**

- [EWL-3812: StyleGuide | Install plugin-php-data-inheritance](https://issues.ama-assn.org/browse/EWL-3812)


## Description

Changes version of Pattern lab from a dev commit to stable 2.7.0
Creates patch file to get in the dev commit we were building from
Installs data-inheritance plugin


## To Test

- [ ] Navigate to styleguide/ and run `composer install`
- [ ] Load the site with `gulp serve` and see that nothing's horribly broken
- [ ] Make yourself a test pattern with json and see that pattern that includes this can now inherit the data


## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

N/A


## Additional Notes

Everyone will have to run composer install after this is merged to update their dependencies.
