### PR TITLE
Give custom JS a better name.

### DIFF
--- a/styleguide/gulpfile.js
+++ b/styleguide/gulpfile.js
@@ -60,7 +60,7 @@ gulp.task('scripts', function () {
   var ds = gulp.src(config.scripts.drupalfiles)
     // unminified for development
     .pipe(sourcemaps.init())
-    .pipe(concat('drupal.js'))
+    .pipe(concat('styleguide-custom.js'))
     .pipe(sourcemaps.write())
     .pipe(gulp.dest(config.scripts.dest));
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

NA

**Github Issue**

NA

**Jira Ticket**

- [EWL-3815: Ticket Title](https://issues.ama-assn.org/browse/EWL-3815)


## Description

As per https://github.com/AmericanMedicalAssociation/ama-d8/pull/17#pullrequestreview-53622324, change name of the JS file that's generated for drupal.

## To Test

- `gulp serve`
- observe `public/assets/js/styleguide-custom.js` exists instead of `drupal.js`


## Relevant Screenshots/GIFs

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add?
