### PR TITLE
EWL-3857 Topics | SG | Mobile: "Topic" Template gutter scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,5 @@ For example, to use the side-by-side Two Up Layout, add the <code>layout_two_up<
 Note: you should not need to nest elements with class <code>.layout</code>.
 
 The <code>.layout</code> and <code>.layout_number_up</code> classes can be added to container elements both in individual patterns (i.e. organisms) and in the Twig templates that include them (e.g. templates). In general, if a specific pattern can be assumed to always use the same layout, it's fine to include the layout within that pattern.
+
+As of 8/8/17 and PR https://issues.ama-assn.org/browse/EWL-3829, use <code>.grid-region_content</code> to add consistent top margins.

--- a/styleguide/source/_patterns/01-molecules/02-blocks/block-cta-with-list/_block-cta-with-list.scss
+++ b/styleguide/source/_patterns/01-molecules/02-blocks/block-cta-with-list/_block-cta-with-list.scss
@@ -11,7 +11,10 @@
 .block_cta-with-list-container {
   background-color: $black-7;
   display: block;
-  padding: $gutter-half $gutter;
+  @include gutter($padding-top-half...);
+  @include gutter($padding-bottom-half...);
+  @include gutter($padding-left-full...);
+  @include gutter($padding-right-full...);
 }
 
 a.block_cta-with-list-container:hover {

--- a/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/_article-preview.scss
+++ b/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/_article-preview.scss
@@ -1,7 +1,11 @@
 .topic_article-preview {
   display: flex;
   @include grid--direction-col();
-  margin-top: -1 * $gutter-half;
+  margin-top: -1 * $gutter-mobile-half;
+
+  @include breakpoint($bp-med) {
+    margin-top: -1 * $gutter-half;
+  }
 }
 
 // Remove inherited margins from article preview fields so that we can set consistent top margins.

--- a/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/_article-preview.scss
+++ b/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/_article-preview.scss
@@ -1,11 +1,7 @@
 .topic_article-preview {
   display: flex;
   @include grid--direction-col();
-  margin-top: -1 * $gutter-mobile-half;
-
-  @include breakpoint($bp-med) {
-    margin-top: -1 * $gutter-half;
-  }
+  @include gutter($margin-top-half-negative...);
 }
 
 // Remove inherited margins from article preview fields so that we can set consistent top margins.

--- a/styleguide/source/_patterns/01-molecules/08-lists/13-list-topic-related-content/_list-topic-related-content.scss
+++ b/styleguide/source/_patterns/01-molecules/08-lists/13-list-topic-related-content/_list-topic-related-content.scss
@@ -15,6 +15,9 @@
 }
 
 .list_topic-related-content_title {
-  font-size: 24px;
   margin-bottom: 0;
+  @include type($font-serif, 21px, $font-weight-medium, 1.3333333333);
+  @include breakpoint($bp-med-home min-width) {
+    @include type($font-serif, 24px, $font-weight-medium, 1.2916666667);
+  }
 }

--- a/styleguide/source/_patterns/01-molecules/08-lists/13-list-topic-related-content/_list-topic-related-content.scss
+++ b/styleguide/source/_patterns/01-molecules/08-lists/13-list-topic-related-content/_list-topic-related-content.scss
@@ -7,7 +7,11 @@
 
 .list_item-topic-related-content {
   margin-bottom: 0;
-  margin-top: $gutter-half;
+  margin-top: $gutter-mobile-half;
+
+  @include breakpoint($bp-med) {
+    margin-top: $gutter-half;
+  }
 }
 
 .list_topic-related-content_title {

--- a/styleguide/source/_patterns/01-molecules/08-lists/13-list-topic-related-content/_list-topic-related-content.scss
+++ b/styleguide/source/_patterns/01-molecules/08-lists/13-list-topic-related-content/_list-topic-related-content.scss
@@ -7,11 +7,7 @@
 
 .list_item-topic-related-content {
   margin-bottom: 0;
-  margin-top: $gutter-mobile-half;
-
-  @include breakpoint($bp-med) {
-    margin-top: $gutter-half;
-  }
+  @include gutter($margin-top-half...);
 }
 
 .list_topic-related-content_title {

--- a/styleguide/source/_patterns/02-organisms/06-topic/01-topic-hero/_topic-hero.scss
+++ b/styleguide/source/_patterns/02-organisms/06-topic/01-topic-hero/_topic-hero.scss
@@ -1,11 +1,19 @@
 .topic_hero .topic_article-preview {
   @include rule-horizontal-bottom(1px, $gray-8, solid);
-  padding: $gutter 0;
+  padding: $gutter-mobile 0;
+
+  @include breakpoint($bp-med) {
+    padding: $gutter 0;
+  }
 }
 
 .topic_hero .topic_article-preview_title {
   display: inline-block;
-  font-size: 36px;
+  font-size: 24px;
+
+  @include breakpoint($bp-small) {
+    font-size: 36px;
+  }
 }
 
 // Display the video field at the bottom of the field order.
@@ -15,7 +23,10 @@
 
 // Ensure top gutters for child elements.
 .topic_hero .topic_article-preview {
-  @include child-top-gutters($gutter-half);
+  @include child-top-gutters($gutter-mobile-half);
+  @include breakpoint($bp-med) {
+    @include child-top-gutters($gutter-half);
+  }
 }
 
 .topic_hero > *:first-child {

--- a/styleguide/source/_patterns/02-organisms/06-topic/01-topic-hero/_topic-hero.scss
+++ b/styleguide/source/_patterns/02-organisms/06-topic/01-topic-hero/_topic-hero.scss
@@ -1,10 +1,7 @@
 .topic_hero .topic_article-preview {
   @include rule-horizontal-bottom(1px, $gray-8, solid);
-  padding: $gutter-mobile 0;
-
-  @include breakpoint($bp-med) {
-    padding: $gutter 0;
-  }
+  @include gutter($padding-top-full...);
+  @include gutter($padding-bottom-full...);
 }
 
 .topic_hero .topic_article-preview_title {
@@ -22,9 +19,9 @@
 
 // Ensure top gutters for child elements.
 .topic_hero .topic_article-preview {
-  @include child-top-gutters($gutter-mobile-half);
+  @include child-top-gutters($gutter-mobile / 2);
   @include breakpoint($bp-med) {
-    @include child-top-gutters($gutter-half);
+    @include child-top-gutters($gutter / 2);
   }
 }
 

--- a/styleguide/source/_patterns/02-organisms/06-topic/01-topic-hero/_topic-hero.scss
+++ b/styleguide/source/_patterns/02-organisms/06-topic/01-topic-hero/_topic-hero.scss
@@ -9,10 +9,9 @@
 
 .topic_hero .topic_article-preview_title {
   display: inline-block;
-  font-size: 24px;
-
-  @include breakpoint($bp-small) {
-    font-size: 36px;
+  @include type($font-serif, 24px, $font-weight-medium, 1.3043478261);
+  @include breakpoint($bp-med min-width) {
+    @include type($font-serif, 36px, $font-weight-medium, 1.25);
   }
 }
 

--- a/styleguide/source/_patterns/02-organisms/06-topic/04-topic-related-content/_topic-related-content.scss
+++ b/styleguide/source/_patterns/02-organisms/06-topic/04-topic-related-content/_topic-related-content.scss
@@ -1,5 +1,5 @@
 .topic_related-content_title {
-  @include rule-horizontal-bottom(1px, $gray-8, solid);
   text-transform: uppercase;
-  padding-bottom: $gutter-half;
+  @include rule-horizontal-bottom(1px, $gray-8, solid);
+  @include gutter($padding-bottom-half...);
 }

--- a/styleguide/source/_patterns/02-organisms/06-topic/04-topic-topic-articles/_topic-topic-articles.scss
+++ b/styleguide/source/_patterns/02-organisms/06-topic/04-topic-topic-articles/_topic-topic-articles.scss
@@ -19,17 +19,9 @@
 
 // Ensure consistent top margins for elements in this section.
 .topic_topic-articles .topic_article-preview > * {
-  margin-top: $gutter-mobile-half;
-
-  @include breakpoint($bp-med) {
-    margin-top: $gutter-half;
-  }
+  @include gutter($margin-top-half...);
 }
 
 .topic_topic-articles .topic_article-preview {
-  padding-bottom: $gutter-mobile;
-
-  @include breakpoint($bp-med) {
-    padding-bottom: $gutter;
-  }
+  @include gutter($padding-bottom-full...);
 }

--- a/styleguide/source/_patterns/02-organisms/06-topic/04-topic-topic-articles/_topic-topic-articles.scss
+++ b/styleguide/source/_patterns/02-organisms/06-topic/04-topic-topic-articles/_topic-topic-articles.scss
@@ -19,9 +19,17 @@
 
 // Ensure consistent top margins for elements in this section.
 .topic_topic-articles .topic_article-preview > * {
-  margin-top: $gutter-half;
+  margin-top: $gutter-mobile-half;
+
+  @include breakpoint($bp-med) {
+    margin-top: $gutter-half;
+  }
 }
 
 .topic_topic-articles .topic_article-preview {
-  padding-bottom: $gutter;
+  padding-bottom: $gutter-mobile;
+
+  @include breakpoint($bp-med) {
+    padding-bottom: $gutter;
+  }
 }

--- a/styleguide/source/_patterns/03-templates/04-topic/_topic.scss
+++ b/styleguide/source/_patterns/03-templates/04-topic/_topic.scss
@@ -1,7 +1,11 @@
 // Topic template.
 .topic {
   .page-title {
-    padding-left: $gutter-half;
+    padding-left: $gutter-mobile-half;
+
+    @include breakpoint($bp-med) {
+      padding-left: $gutter-half;
+    }
   }
 }
 

--- a/styleguide/source/_patterns/03-templates/04-topic/_topic.scss
+++ b/styleguide/source/_patterns/03-templates/04-topic/_topic.scss
@@ -1,11 +1,7 @@
 // Topic template.
 .topic {
   .page-title {
-    padding-left: $gutter-mobile-half;
-
-    @include breakpoint($bp-med) {
-      padding-left: $gutter-half;
-    }
+    @include gutter($padding-left-half...);
   }
 }
 

--- a/styleguide/source/assets/css/scss/generic/_mixins.scss
+++ b/styleguide/source/assets/css/scss/generic/_mixins.scss
@@ -69,6 +69,18 @@
   }
 }
 
+// Provide a gutter mixin to make responsive gutter variables available.
+// Usage: @include gutter($padding-left-full...);
+// The "..." allows SCSS to pass arguments as a list.
+// Will output one direction, e.g. "padding-left: 20px;".
+// See _variables.scss for a list of style vars that can be passed.
+@mixin gutter($type, $direction, $width, $width-mobile) {
+  #{$type}-#{$direction}: #{$width-mobile};
+  @include breakpoint($bp-med) {
+    #{$type}-#{$direction}: #{$width};
+  }
+}
+
 // For patterns that are flex-direction: column, ensure
 // the appropriate top margins between them. The other half
 // of the gutter should be provided by the top margin of

--- a/styleguide/source/assets/css/scss/generic/_mixins.scss
+++ b/styleguide/source/assets/css/scss/generic/_mixins.scss
@@ -76,10 +76,10 @@
 @mixin child-top-gutters($height) {
   > * {
   //> *:nth-child(n + 2) > *:nth-child(n + 2) {
-    margin-top: $gutter-mobile-half;
+    margin-top: $gutter-mobile / 2;
 
     @include breakpoint($bp-med) {
-      margin-top: $gutter-half;
+      margin-top: $gutter / 2;
     }
   }
 }

--- a/styleguide/source/assets/css/scss/generic/_mixins.scss
+++ b/styleguide/source/assets/css/scss/generic/_mixins.scss
@@ -74,7 +74,7 @@
 // The "..." allows SCSS to pass arguments as a list.
 // Will output one direction, e.g. "padding-left: 20px;".
 // See _variables.scss for a list of style vars that can be passed.
-@mixin gutter($type, $direction, $width, $width-mobile) {
+@mixin gutter($type, $direction, $width: $gutter, $width-mobile: $gutter-mobile) {
   #{$type}-#{$direction}: #{$width-mobile};
   @include breakpoint($bp-med) {
     #{$type}-#{$direction}: #{$width};

--- a/styleguide/source/assets/css/scss/generic/_mixins.scss
+++ b/styleguide/source/assets/css/scss/generic/_mixins.scss
@@ -76,6 +76,10 @@
 @mixin child-top-gutters($height) {
   > * {
   //> *:nth-child(n + 2) > *:nth-child(n + 2) {
-    margin-top: $gutter-half;
+    margin-top: $gutter-mobile-half;
+
+    @include breakpoint($bp-med) {
+      margin-top: $gutter-half;
+    }
   }
 }

--- a/styleguide/source/assets/css/scss/generic/_variables.scss
+++ b/styleguide/source/assets/css/scss/generic/_variables.scss
@@ -77,5 +77,7 @@ $bp-med-home: 740px;
 $bp-large-home: 1251px;
 
 // Grid variables.
+$gutter-mobile: 20px;
+$gutter-mobile-half: $gutter-mobile / 2 ;
 $gutter: 28px;
 $gutter-half: $gutter / 2;

--- a/styleguide/source/assets/css/scss/generic/_variables.scss
+++ b/styleguide/source/assets/css/scss/generic/_variables.scss
@@ -80,8 +80,7 @@ $bp-large-home: 1251px;
 $gutter-mobile: 20px;
 $gutter: 28px;
 
-// Provide a gutter mixin to make responsive gutter variables available:
-// Some pre-made styles. Pass to gutter() mixin.
+// Some pre-made styles. Pass to gutter() mixin - see _mixins.scss.
 // Feel free to add a new style following the naming conventions.
 $margin-top-half: margin, top, $gutter / 2, $gutter-mobile / 2;
 $margin-top-half-negative: margin, top, -$gutter / 2, -$gutter-mobile / 2;
@@ -96,13 +95,3 @@ $padding-bottom-full: padding, bottom, $gutter, $gutter-mobile;
 $padding-bottom-half: padding, bottom, $gutter / 2, $gutter-mobile / 2;
 $padding-left-full: padding, left, $gutter, $gutter-mobile;
 $padding-left-half: padding, left, $gutter / 2,  $gutter-mobile / 2;
-
-// Usage: @include gutter($padding-left-full...);
-// The "..." allows SCSS to pass arguments as a list.
-// Will output one direction, e.g. "padding-left: 20px;".
-@mixin gutter($type, $direction, $width, $width-mobile) {
-  #{$type}-#{$direction}: #{$width-mobile};
-  @include breakpoint($bp-med) {
-    #{$type}-#{$direction}: #{$width};
-  }
-}

--- a/styleguide/source/assets/css/scss/generic/_variables.scss
+++ b/styleguide/source/assets/css/scss/generic/_variables.scss
@@ -77,22 +77,25 @@ $bp-med-home: 740px;
 $bp-large-home: 1251px;
 
 // Grid variables.
-// @todo - try rems; @extend gutter (@extend would include breakpoints)
 $gutter-mobile: 20px;
-$gutter-mobile-half: $gutter-mobile / 2; // @todo remove
 $gutter: 28px;
-$gutter-half: $gutter / 2; // @todo remove
 
 // Provide a gutter mixin to make responsive gutter variables available:
 // Some pre-made styles. Pass to gutter() mixin.
 // Feel free to add a new style following the naming conventions.
-$padding-left-full: padding, left, $gutter, $gutter-mobile;
-$padding-top-full: padding, top, $gutter, $gutter-mobile;
-$margin-left-full-negative: margin, left, -$gutter, -$gutter-mobile;
+$margin-top-half: margin, top, $gutter / 2, $gutter-mobile / 2;
+$margin-top-half-negative: margin, top, -$gutter / 2, -$gutter-mobile / 2;
 $margin-top-full-negative: margin, top, -$gutter, -$gutter-mobile;
-$padding-right-half: padding, right, $gutter / 2,  $gutter-mobile / 2;
-$padding-left-half: padding, left, $gutter / 2,  $gutter-mobile / 2;
+$margin-left-full-negative: margin, left, -$gutter, -$gutter-mobile;
 
+$padding-top-full: padding, top, $gutter, $gutter-mobile;
+$padding-top-half: padding, top, $gutter / 2, $gutter-mobile / 2;
+$padding-right-full: padding, right, $gutter,  $gutter-mobile;
+$padding-right-half: padding, right, $gutter / 2,  $gutter-mobile / 2;
+$padding-bottom-full: padding, bottom, $gutter, $gutter-mobile;
+$padding-bottom-half: padding, bottom, $gutter / 2, $gutter-mobile / 2;
+$padding-left-full: padding, left, $gutter, $gutter-mobile;
+$padding-left-half: padding, left, $gutter / 2,  $gutter-mobile / 2;
 
 // Usage: @include gutter($padding-left-full...);
 // The "..." allows SCSS to pass arguments as a list.

--- a/styleguide/source/assets/css/scss/generic/_variables.scss
+++ b/styleguide/source/assets/css/scss/generic/_variables.scss
@@ -77,7 +77,29 @@ $bp-med-home: 740px;
 $bp-large-home: 1251px;
 
 // Grid variables.
+// @todo - try rems; @extend gutter (@extend would include breakpoints)
 $gutter-mobile: 20px;
-$gutter-mobile-half: $gutter-mobile / 2 ;
+$gutter-mobile-half: $gutter-mobile / 2; // @todo remove
 $gutter: 28px;
-$gutter-half: $gutter / 2;
+$gutter-half: $gutter / 2; // @todo remove
+
+// Provide a gutter mixin to make responsive gutter variables available:
+// Some pre-made styles. Pass to gutter() mixin.
+// Feel free to add a new style following the naming conventions.
+$padding-left-full: padding, left, $gutter, $gutter-mobile;
+$padding-top-full: padding, top, $gutter, $gutter-mobile;
+$margin-left-full-negative: margin, left, -$gutter, -$gutter-mobile;
+$margin-top-full-negative: margin, top, -$gutter, -$gutter-mobile;
+$padding-right-half: padding, right, $gutter / 2,  $gutter-mobile / 2;
+$padding-left-half: padding, left, $gutter / 2,  $gutter-mobile / 2;
+
+
+// Usage: @include gutter($padding-left-full...);
+// The "..." allows SCSS to pass arguments as a list.
+// Will output one direction, e.g. "padding-left: 20px;".
+@mixin gutter($type, $direction, $width, $width-mobile) {
+  #{$type}-#{$direction}: #{$width-mobile};
+  @include breakpoint($bp-med) {
+    #{$type}-#{$direction}: #{$width};
+  }
+}

--- a/styleguide/source/assets/css/scss/objects/_layout.scss
+++ b/styleguide/source/assets/css/scss/objects/_layout.scss
@@ -20,7 +20,7 @@
 .container {
   max-width: $max-width;
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 0;
 
   @include breakpoint($bp-med) {
     padding: 0 30px;
@@ -30,17 +30,26 @@
 // Use on the container that should have gutters and use flexbox.
 .grid {
 	@include grid();
-	margin: -$gutter 0 0 -$gutter;
+	margin: -$gutter-mobile 0 0 -$gutter-mobile;
+	@include breakpoint($bp-med) {
+		margin: -$gutter 0 0 -$gutter;
+	}
 }
 
 // Apply the gutters to individual cells.
 .grid-region {
-	margin-top: $gutter;
+	padding-top: $gutter-mobile;
+	@include breakpoint($bp-med) {
+		padding-top: $gutter;
+	}
 }
 
 // Add top margins between content within grid regions.
 .grid-region_content {
-	padding-top: $gutter;
+	padding-top: $gutter-mobile;
+	@include breakpoint($bp-small) {
+		padding-top: $gutter;
+	}
 }
 
 // Don't add padding to the first/last children of nested grids, since the parent
@@ -59,29 +68,33 @@
 
 // Column-width classes..
 .col-width-3 {
-	padding: 0 $gutter-half 0 $gutter-half;
+	padding: 0 $gutter-mobile-half 0 $gutter-mobile-half;
 	@include breakpoint($bp-med) {
 		@include grid-_unit--cols(3);
+		padding: 0 $gutter-half 0 $gutter-half;
 	}
 }
 
 .col-width-6 {
-	padding: 0 $gutter-half 0 $gutter-half;
+	padding: 0 $gutter-mobile-half 0 $gutter-mobile-half;
 	@include breakpoint($bp-med) {
 		@include grid-_unit--cols(6);
+		padding: 0 $gutter-half 0 $gutter-half;
 	}
 }
 
 .col-width-9 {
-	padding: 0 $gutter-half 0 $gutter-half;
+	padding: 0 $gutter-mobile-half 0 $gutter-mobile-half;
 	@include breakpoint($bp-med) {
 		@include grid-_unit--cols(9);
+		padding: 0 $gutter-half 0 $gutter-half;
 	}
 }
 
 .col-width-12 {
-	padding: 0 $gutter-half 0 $gutter-half;
+	padding: 0 $gutter-mobile-half 0 $gutter-mobile-half;
 	@include breakpoint($bp-med) {
 		@include grid-_unit--cols(12);
+		padding: 0 $gutter-half 0 $gutter-half;
 	}
 }

--- a/styleguide/source/assets/css/scss/objects/_layout.scss
+++ b/styleguide/source/assets/css/scss/objects/_layout.scss
@@ -30,26 +30,17 @@
 // Use on the container that should have gutters and use flexbox.
 .grid {
 	@include grid();
-	margin: -$gutter-mobile 0 0 -$gutter-mobile;
-	@include breakpoint($bp-med) {
-		margin: -$gutter 0 0 -$gutter;
-	}
+	@include gutter($margin-top-full-negative...);
 }
 
 // Apply the gutters to individual cells.
 .grid-region {
-	padding-top: $gutter-mobile;
-	@include breakpoint($bp-med) {
-		padding-top: $gutter;
-	}
+	@include gutter($padding-top-full...);
 }
 
 // Add top margins between content within grid regions.
 .grid-region_content {
-	padding-top: $gutter-mobile;
-	@include breakpoint($bp-small) {
-		padding-top: $gutter;
-	}
+	@include gutter($padding-top-full...);
 }
 
 // Don't add padding to the first/last children of nested grids, since the parent
@@ -68,33 +59,33 @@
 
 // Column-width classes..
 .col-width-3 {
-	padding: 0 $gutter-mobile-half 0 $gutter-mobile-half;
+	@include gutter($padding-right-half...);
+	@include gutter($padding-left-half...);
 	@include breakpoint($bp-med) {
 		@include grid-_unit--cols(3);
-		padding: 0 $gutter-half 0 $gutter-half;
 	}
 }
 
 .col-width-6 {
-	padding: 0 $gutter-mobile-half 0 $gutter-mobile-half;
+	@include gutter($padding-right-half...);
+	@include gutter($padding-left-half...);
 	@include breakpoint($bp-med) {
 		@include grid-_unit--cols(6);
-		padding: 0 $gutter-half 0 $gutter-half;
 	}
 }
 
 .col-width-9 {
-	padding: 0 $gutter-mobile-half 0 $gutter-mobile-half;
+	@include gutter($padding-right-half...);
+	@include gutter($padding-left-half...);
 	@include breakpoint($bp-med) {
 		@include grid-_unit--cols(9);
-		padding: 0 $gutter-half 0 $gutter-half;
 	}
 }
 
 .col-width-12 {
-	padding: 0 $gutter-mobile-half 0 $gutter-mobile-half;
+	@include gutter($padding-right-half...);
+	@include gutter($padding-left-half...);
 	@include breakpoint($bp-med) {
 		@include grid-_unit--cols(12);
-		padding: 0 $gutter-half 0 $gutter-half;
 	}
 }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-3857: Topics | SG | Mobile: "Topic" Template gutter scaling](https://issues.ama-assn.org/browse/EWL-3857)


## Description

- Added a new mixin, `gutter()`, to use in conjunction with SCSS variables that contain a list of properties to define the desired gutter. Documented in comments in _layout.scss and _mixins.scss
- Implemented the mixin for elements that were already styled with gutters in previous PRs


## To Test

- [x] Templates > Topic > Topic: resize to mobile and desktop and look at the gutters - make sure they look consistent-ish
- [x] Review the code and make sure the approach makes sense


## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

- [ ] Maybe rebase newer work?


## Additional Notes

N/A
