### PR TITLE
EWL-3882 Topics | SG | Remove Email Subscription pattern from Topic template

### DIFF
--- a/styleguide/source/_patterns/02-organisms/06-topic/07-topic-email-subscription/topic-email-subscription.md
+++ b/styleguide/source/_patterns/02-organisms/06-topic/07-topic-email-subscription/topic-email-subscription.md
@@ -4,4 +4,6 @@ title: "Topic Email Subscription"
 
 An email subscription form for a Topic page. It contains a Title, description, CTA button (required), Check box, and description.
 
-[EWL-3774](https://issues.ama-assn.org/browse/EWL-3774)
+Created in: [EWL-3774](https://issues.ama-assn.org/browse/EWL-3774)
+
+**As of 8/11/2017 this pattern was removed from the Topic page MVP scope, so it's currently not being used anywhere. This work is tracked in [EWL-3882](https://issues.ama-assn.org/browse/EWL-3882). 

--- a/styleguide/source/_patterns/03-templates/04-topic/topic.twig
+++ b/styleguide/source/_patterns/03-templates/04-topic/topic.twig
@@ -14,7 +14,6 @@
     <section class="topic_content col-width-6 grid-region">
       {% include 'organisms-topic-hero' %}
       {% include 'organisms-topic-related-articles' with { 'class': 'grid-region_content' } %}
-      {% include 'organisms-topic-email-subscription' with { 'class': 'grid-region_content' } %}
     </section>
 
     <aside class="topic_rail-right col-width-3 grid-region">


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-3882: Topics | SG | Remove Email Subscription pattern from Topic template](https://issues.ama-assn.org/browse/EWL-3882)


## Description

Removes the Email Subscription from the Topic template pattern. Documents the reason why in the `.md` file for that pattern.


## To Test

- [x] Visit Templates > Topic > Topic: verify that Email Subscription form is not present
- [x] Visit Organisms > Topic > Topic Email Subscription: read text and see if it makes sense


## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

N/A


## Additional Notes

N/A
