### PR TITLE
EWL-3869: Card heights should be equal to tallest card

### DIFF
--- a/styleguide/source/_patterns/01-molecules/12-ec/00-ec-card-course/_ec-card-course.scss
+++ b/styleguide/source/_patterns/01-molecules/12-ec/00-ec-card-course/_ec-card-course.scss
@@ -6,10 +6,6 @@
   display: inline-block;
   width: 100%;
 
-  &:hover {
-    background-color: $gray-light-4;
-  }
-
   @include breakpoint($bp-small $bp-med) {
     padding: 30px 30px 0 30px;
   }

--- a/styleguide/source/_patterns/02-organisms/05-ec/03-ec-tabs-course-browser/_ec-tabs-course-browser.scss
+++ b/styleguide/source/_patterns/02-organisms/05-ec/03-ec-tabs-course-browser/_ec-tabs-course-browser.scss
@@ -189,6 +189,10 @@
 .tabs-course_browser_list-cards-item {
   width: 100%;
   margin-bottom: 0;
+  background: $black-7;
+  :hover {
+    background: $gray-light-3;
+  }
 
   &:nth-of-type(4n),
   &:nth-of-type(5n) {

--- a/styleguide/source/_patterns/03-templates/02-ec-home/_ec-home.scss
+++ b/styleguide/source/_patterns/03-templates/02-ec-home/_ec-home.scss
@@ -184,9 +184,6 @@ li.tabs-course_browser_list-cards-item:nth-child(odd) .ec_card-course_duration {
 
   .ec_cards-course-bundle .layout_item:nth-child(even) .ec-card-course-bundle {
     background: white;
-    &:hover {
-      background: #f7f7f7;
-    }
   }
 }
 


### PR DESCRIPTION
Move background color on EC Tabs Course Cards up the food-chain to the li.

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)
- [EWL-3869: Card heights should be equal to tallest card](https://issues.ama-assn.org/browse/EWL-3869)

## Description

Fixing issue with uneven heights on EC Tabs Course Cards.
@see https://github.com/AmericanMedicalAssociation/AMA-Corporate-site/pull/1160

## To Test

- [ ] Add steps to test this feature


## Relevant Screenshots/GIFs

![image](https://user-images.githubusercontent.com/242217/29339925-3ce5d628-81e2-11e7-9a7f-9129a3f30cb9.png)

## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add?
