### PR TITLE
EWL-3838: removes grid mixin directly used in layouts.

### DIFF
--- a/styleguide/source/_patterns/01-molecules/01-layouts/deprecated/03-layout-three-up/_layout-three-up.scss
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/deprecated/03-layout-three-up/_layout-three-up.scss
@@ -7,11 +7,6 @@
     padding: 2em;
     text-align: center;
   }
-
-  // Layout default setup.
-  .layout {
-    @include grid();
-  }
 }
 
 .flexbox .layout.layout_three_up {
@@ -20,7 +15,6 @@
 }
 
 .layout_three_up-row {
-  @include grid();
     width: 100%;
 }
 

--- a/styleguide/source/_patterns/01-molecules/01-layouts/deprecated/03-layout-three-up/layout-three-up.twig
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/deprecated/03-layout-three-up/layout-three-up.twig
@@ -2,14 +2,11 @@
   <div class="layout_three_up-row">
     <div class="layout_three_up-primary">
       <div class="layout_container">3-up</div>
-      <div class="layout_container">3-up</div>
     </div>
     <div class="layout_three_up-secondary">
       <div class="layout_container">3-up</div>
-      <div class="layout_container">3-up</div>
     </div>
     <div class="layout_three_up-tertiary">
-      <div class="layout_container">3-up</div>
       <div class="layout_container">3-up</div>
     </div>
   </div>

--- a/styleguide/source/_patterns/01-molecules/01-layouts/deprecated/08-layout-four-up/_layout-four-up.scss
+++ b/styleguide/source/_patterns/01-molecules/01-layouts/deprecated/08-layout-four-up/_layout-four-up.scss
@@ -1,8 +1,3 @@
-// Layout default setup.
-.layout {
-  @include grid();
-}
-
 .flexbox .layout.layout-four-up {
   @include grid__unit--cols(12);
   justify-content: flex-start;


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWL-3838: SG | Clean up use of grid() mixin to use .grid class instead](https://issues.ama-assn.org/browse/EWL-3838)


## Description
The `layout` class provides the `@include grid();` mixin for use. Removes the `grid();`  from being used directly in layouts. 

Note: This work is part of the layout refactoring effort.

## To Test

- [ ] Verify that `@include grid();` is only used to set up the layouts in the `_layout.scss` sheet and not directly used in other places.


## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

N/A


## Additional Notes

N/A
