### PR TITLE
[EWL-3869] : adds a height to ec cards so they expand to the tallest

### DIFF
--- a/styleguide/source/_patterns/01-molecules/12-ec/00-ec-card-course/_ec-card-course.scss
+++ b/styleguide/source/_patterns/01-molecules/12-ec/00-ec-card-course/_ec-card-course.scss
@@ -5,6 +5,7 @@
   color: $black;
   display: inline-block;
   width: 100%;
+  height: 100%;
 
   &:hover {
     background-color: $gray-light-4;

--- a/styleguide/source/_patterns/01-molecules/12-ec/02-ec-card-course-bundle/_ec-card-course-bundle.scss
+++ b/styleguide/source/_patterns/01-molecules/12-ec/02-ec-card-course-bundle/_ec-card-course-bundle.scss
@@ -6,6 +6,7 @@
   padding: 24px;
   width: 100%;
   margin-bottom: 20px;
+  height: 100%;
 
   @include type($font-sans-serif, 18px, $font-weight-medium, 1.3888888889);
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-3869: Card heights should be equal to tallest card](https://issues.ama-assn.org/browse/EWL-3869)


## Description

EC Course bundle cards and course card rows did not expand to the height of the tallest card. Added a `height: 100%` style to fix this.

## To Test

- [x] Go to Templates > EC (any)
- [x] Using the Inspector, add some additional text to a Course or Course Bundle card
- [x] See that the row height (tablet & up) expands to the height of the tallest card


## Relevant Screenshots/GIFs

Issue:
![image](https://user-images.githubusercontent.com/28711067/29425035-6d9f93e2-8347-11e7-85bf-05cc23d8dd6c.png)

Fix: 
![screen shot 2017-08-17 at 12 27 37 pm](https://user-images.githubusercontent.com/28711067/29425080-92810128-8347-11e7-8d01-6979c5f30f9a.png)

![screen shot 2017-08-17 at 12 27 52 pm](https://user-images.githubusercontent.com/28711067/29425083-9512504a-8347-11e7-8575-f7fb28c20c41.png)


## Remaining Tasks

Add to Corporate


## Additional Notes

N/A
