### PR TITLE
Bugfix/ewl 3868 panelizer ipe

### DIFF
--- a/styleguide/source/_patterns/00-atoms/06-buttons/02-button/_button.scss
+++ b/styleguide/source/_patterns/00-atoms/06-buttons/02-button/_button.scss
@@ -1,6 +1,6 @@
-%button,
-button,
-.button {
+:not('panels-ipe-tray') button,
+:not('panels-ipe-tray') %button,
+:not('panels-ipe-tray') .button {
   @extend %background-transition;
   /* stylelint-disable property-no-vendor-prefix */
   -moz-appearance: none;

--- a/styleguide/source/_patterns/01-molecules/04-forms/01-form-item/_form-item.scss
+++ b/styleguide/source/_patterns/01-molecules/04-forms/01-form-item/_form-item.scss
@@ -1,7 +1,7 @@
 /*------------------------------------*\
     $INPUT WRAP
 \*------------------------------------*/
-.form-item {
+:not('panels-ipe-tray') .form-item {
   position: relative;
   width: 100%;
   float: left;

--- a/styleguide/source/assets/css/scss/base/_forms.scss
+++ b/styleguide/source/assets/css/scss/base/_forms.scss
@@ -1,250 +1,251 @@
 /*------------------------------------*\
     $FORMS
 \*------------------------------------*/
-form ol,
-form ul {
-  list-style: none;
-  margin-left: 0;
-}
-
-fieldset {
-  border: 0;
-  padding: 0;
-  margin: 0;
-}
-
-legend {
-  margin-bottom: 0.5em;
-}
-
-label {
-  display: block;
-}
-
-button,
-input,
-select,
-textarea {
-    font-family: inherit;
-    font-size: 100%;
-    margin: 0 1px 0;
-}
-
-// Global input styles
-input[type="text"],
-input[type="password"],
-input[type="email"],
-input[type="url"],
-input[type="date"],
-input[type="month"],
-input[type="time"],
-input[type="datetime"],
-input[type="datetime-local"],
-input[type="week"],
-input[type="number"],
-input[type="search"],
-input[type="tel"],
-input[type="color"],
-select,
-textarea {
-  /* stylelint-disable property-no-vendor-prefix */
-  -webkit-appearance: none;
-  /* stylelint-enable */
-  position: relative;
-  height: 60px;
-  width: 100%;
-  background-color: $white;
-  border: 1px solid $gray-8;
-  border-radius: 0;
-  outline: none;
-  padding: 0 15px;
-
-  &:focus,
-  &:active {
-    border: 2px solid $purple;
-    outline: none;
-    padding: 0 14px;
+:not('panels-ipe-tray'){
+  form ol,
+  form ul {
+    list-style: none;
+    margin-left: 0;
   }
 
-  &:after {
+  fieldset {
+    border: 0;
+    padding: 0;
+    margin: 0;
+  }
+
+  legend {
+    margin-bottom: 0.5em;
+  }
+
+  label {
     display: block;
-    content: "";
-    position: absolute;
-    top: 0;
-    right: -30px;
-    width: 30px;
-    height: 30px;
-    background-color: red;
-
   }
 
-  &.error {
-    border: 2px solid $red-darker;
-    padding: 0 14px;
+  button,
+  input,
+  select,
+  textarea {
+      font-family: inherit;
+      font-size: 100%;
+      margin: 0 1px 0;
   }
 
-  &.valid {
-    color: $black;
-  }
-}
-
-// Overriding textarea styles
-textarea {
-  height: 250px;
-  padding: 15px;
-
-  &:focus,
-  &:active {
-    border: 2px solid $purple;
+  // Global input styles
+  input[type="text"],
+  input[type="password"],
+  input[type="email"],
+  input[type="url"],
+  input[type="date"],
+  input[type="month"],
+  input[type="time"],
+  input[type="datetime"],
+  input[type="datetime-local"],
+  input[type="week"],
+  input[type="number"],
+  input[type="search"],
+  input[type="tel"],
+  input[type="color"],
+  select,
+  textarea {
+    /* stylelint-disable property-no-vendor-prefix */
+    -webkit-appearance: none;
+    /* stylelint-enable */
+    position: relative;
+    height: 60px;
+    width: 100%;
+    background-color: $white;
+    border: 1px solid $gray-8;
+    border-radius: 0;
     outline: none;
-    padding: 14px;
-  }
+    padding: 0 15px;
 
-  &.error {
-    padding: 14px;
-  }
-}
+    &:focus,
+    &:active {
+      border: 2px solid $purple;
+      outline: none;
+      padding: 0 14px;
+    }
 
-select {
-  background-image: url("../../assets/icons/svg/opendropdown.svg");
-  background-position: calc(100% - 8px) 52%;
-  background-repeat: no-repeat;
-  padding-right: 30px;
-  -moz-appearance: none; /*removes default dropdown arrow in Firefox*/
-  text-indent: 0.01px; /*removes default dropdown arrow in Firefox*/
-  text-overflow: ''; /*removes default dropdown arrow in Firefox*/
-}
-
-// Placeholder text styles
-::-webkit-input-placeholder { /* Chrome */
-  color: $gray-8;
-}
-:-ms-input-placeholder { /* IE 10+ */
-  color: $gray-8;
-}
-::-moz-placeholder { /* Firefox 19+ */
-  color: $gray-8;
-  opacity: 1;
-}
-:-moz-placeholder { /* Firefox 4 - 18 */
-  color: $gray-8;
-  opacity: 1;
-}
-
-// Requried label error styles
-label {
-  &.error {
-    @extend %b4;
-    display: block;
-    color: $red-darker;
-    margin-top: 4px;
-    clear: both;
-  }
-}
-
-// Checkbox and radio button styles
-input[type="checkbox"],
-input[type="radio"] {
-  @extend %element-invisible;
-
-  // Label styles
-  + label {
-    margin: 0 0 0.3em;
-
-    // Custom checkboxes and radio buttons
-    &:before {
-      position: relative;
-      top: 0.15em;
-      display: inline-block;
+    &:after {
+      display: block;
       content: "";
-      width: 20px;
-      height: 20px;
-      background-image: url("../../assets/icons/svg/radio.svg");
-      background-position: 0px 0px;
-      background-size: 20px;
-      background-repeat: no-repeat;
-      margin-right: 10px;
+      position: absolute;
+      top: 0;
+      right: -30px;
+      width: 30px;
+      height: 30px;
+      background-color: red;
+
+    }
+
+    &.error {
+      border: 2px solid $red-darker;
+      padding: 0 14px;
+    }
+
+    &.valid {
+      color: $black;
     }
   }
 
-  // Active styles
-  &:checked + label {
-    font-weight: 700;
+  // Overriding textarea styles
+  textarea {
+    height: 250px;
+    padding: 15px;
 
-    &:before {
+    &:focus,
+    &:active {
+      border: 2px solid $purple;
+      outline: none;
+      padding: 14px;
+    }
+
+    &.error {
+      padding: 14px;
+    }
+  }
+
+  select {
+    background-image: url("../../assets/icons/svg/opendropdown.svg");
+    background-position: calc(100% - 8px) 52%;
+    background-repeat: no-repeat;
+    padding-right: 30px;
+    -moz-appearance: none; /*removes default dropdown arrow in Firefox*/
+    text-indent: 0.01px; /*removes default dropdown arrow in Firefox*/
+    text-overflow: ''; /*removes default dropdown arrow in Firefox*/
+  }
+
+  // Placeholder text styles
+  ::-webkit-input-placeholder { /* Chrome */
+    color: $gray-8;
+  }
+  :-ms-input-placeholder { /* IE 10+ */
+    color: $gray-8;
+  }
+  ::-moz-placeholder { /* Firefox 19+ */
+    color: $gray-8;
+    opacity: 1;
+  }
+  :-moz-placeholder { /* Firefox 4 - 18 */
+    color: $gray-8;
+    opacity: 1;
+  }
+
+  // Requried label error styles
+  label {
+    &.error {
+      @extend %b4;
+      display: block;
+      color: $red-darker;
+      margin-top: 4px;
+      clear: both;
+    }
+  }
+
+  // Checkbox and radio button styles
+  input[type="checkbox"],
+  input[type="radio"] {
+    @extend %element-invisible;
+
+    // Label styles
+    + label {
+      margin: 0 0 0.3em;
+
+      // Custom checkboxes and radio buttons
+      &:before {
+        position: relative;
+        top: 0.15em;
+        display: inline-block;
+        content: "";
+        width: 20px;
+        height: 20px;
+        background-image: url("../../assets/icons/svg/radio.svg");
+        background-position: 0px 0px;
+        background-size: 20px;
+        background-repeat: no-repeat;
+        margin-right: 10px;
+      }
+    }
+
+    // Active styles
+    &:checked + label {
+      font-weight: 700;
+
+      &:before {
+        background-position: 0px -25px;
+      }
+    }
+
+    // Tab focus styles
+    &:focus + label {
+      font-weight: 700;
+    }
+  }
+
+  // Add radius curves to radio buttons
+  input[type="checkbox"] {
+    + label:before {
+      background-image: url("../../assets/icons/svg/checkbox.svg");
+    }
+
+    &:checked + label:before {
       background-position: 0px -25px;
     }
   }
 
-  // Tab focus styles
-  &:focus + label {
-    font-weight: 700;
-  }
-}
-
-// Add radius curves to radio buttons
-input[type="checkbox"] {
-  + label:before {
-    background-image: url("../../assets/icons/svg/checkbox.svg");
+  input[type="search"] {
+    /* stylelint-disable property-no-vendor-prefix */
+    -webkit-appearance: none;
+    /* stylelint-enable */
+    border-radius: 0;
   }
 
-  &:checked + label:before {
-    background-position: 0px -25px;
-  }
-}
-
-input[type="search"] {
-  /* stylelint-disable property-no-vendor-prefix */
-  -webkit-appearance: none;
-  /* stylelint-enable */
-  border-radius: 0;
-}
-
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  /* stylelint-disable property-no-vendor-prefix */
-  -webkit-appearance: none;
-  /* stylelint-enable */
-}
-
-//Form Field Container
-.field-container {
-  margin-bottom: $space;
-}
-
-.inline-form {
-  fieldset,
-  .inline-container {
-    position: relative;
+  input[type="search"]::-webkit-search-cancel-button,
+  input[type="search"]::-webkit-search-decoration {
+    /* stylelint-disable property-no-vendor-prefix */
+    -webkit-appearance: none;
+    /* stylelint-enable */
   }
 
-  input[type=submit],
-  button,
-  .btn {
-    padding: 0.65rem 1.3rem;
-    background: $gray-dark;
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: 1;
-    width: auto;
+  //Form Field Container
+  .field-container {
+    margin-bottom: $space;
+  }
 
-    &:hover,
-    &:focus {
-      background: $gray;
-      color: $white;
+  .inline-form {
+    fieldset,
+    .inline-container {
+      position: relative;
+    }
+
+    input[type=submit],
+    button,
+    .btn {
+      padding: 0.65rem 1.3rem;
+      background: $gray-dark;
+      position: absolute;
+      top: 0;
+      right: 0;
+      z-index: 1;
+      width: auto;
+
+      &:hover,
+      &:focus {
+        background: $gray;
+        color: $white;
+      }
     }
   }
-}
 
-/* Validation */
-.has-error {
-  border-color: $error;
+  /* Validation */
+  .has-error {
+    border-color: $error;
+  }
+  .is-valid {
+    border-color: $valid;
+  }
 }
-.is-valid {
-  border-color: $valid;
-}
-
 
 
 

--- a/styleguide/source/assets/css/scss/base/_forms.scss
+++ b/styleguide/source/assets/css/scss/base/_forms.scss
@@ -3,14 +3,14 @@
 \*------------------------------------*/
 form ol,
 form ul {
-	list-style: none;
-	margin-left: 0;
+  list-style: none;
+  margin-left: 0;
 }
 
 fieldset {
-	border: 0;
-	padding: 0;
-	margin: 0;
+  border: 0;
+  padding: 0;
+  margin: 0;
 }
 
 legend {
@@ -18,7 +18,7 @@ legend {
 }
 
 label {
-	display: block;
+  display: block;
 }
 
 button,
@@ -47,9 +47,9 @@ input[type="tel"],
 input[type="color"],
 select,
 textarea {
-	/* stylelint-disable property-no-vendor-prefix */
+  /* stylelint-disable property-no-vendor-prefix */
   -webkit-appearance: none;
-	/* stylelint-enable */
+  /* stylelint-enable */
   position: relative;
   height: 60px;
   width: 100%;
@@ -194,55 +194,55 @@ input[type="checkbox"] {
 }
 
 input[type="search"] {
-	/* stylelint-disable property-no-vendor-prefix */
+  /* stylelint-disable property-no-vendor-prefix */
   -webkit-appearance: none;
-	/* stylelint-enable */
-	border-radius: 0;
+  /* stylelint-enable */
+  border-radius: 0;
 }
 
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
-	/* stylelint-disable property-no-vendor-prefix */
-	-webkit-appearance: none;
-	/* stylelint-enable */
+  /* stylelint-disable property-no-vendor-prefix */
+  -webkit-appearance: none;
+  /* stylelint-enable */
 }
 
 //Form Field Container
 .field-container {
-	margin-bottom: $space;
+  margin-bottom: $space;
 }
 
 .inline-form {
-	fieldset,
+  fieldset,
   .inline-container {
-		position: relative;
-	}
+    position: relative;
+  }
 
-	input[type=submit],
-	button,
-	.btn {
-		padding: 0.65rem 1.3rem;
-		background: $gray-dark;
-		position: absolute;
-		top: 0;
-		right: 0;
-		z-index: 1;
-		width: auto;
+  input[type=submit],
+  button,
+  .btn {
+    padding: 0.65rem 1.3rem;
+    background: $gray-dark;
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 1;
+    width: auto;
 
-		&:hover,
-		&:focus {
-			background: $gray;
-			color: $white;
-		}
-	}
+    &:hover,
+    &:focus {
+      background: $gray;
+      color: $white;
+    }
+  }
 }
 
 /* Validation */
 .has-error {
-	border-color: $error;
+  border-color: $error;
 }
 .is-valid {
-	border-color: $valid;
+  border-color: $valid;
 }
 
 

--- a/styleguide/source/assets/css/scss/base/_links.scss
+++ b/styleguide/source/assets/css/scss/base/_links.scss
@@ -1,5 +1,5 @@
 /* Links */
-a {
+:not('panels-ipe-tray') a {
   @extend %text-transition;
   color: $black;
   text-decoration: none;

--- a/styleguide/source/assets/css/scss/generic/_reset.scss
+++ b/styleguide/source/assets/css/scss/generic/_reset.scss
@@ -3,7 +3,7 @@
 \*------------------------------------*/
 
 /* Border-Box http:/paulirish.com/2012/box-sizing-border-box-ftw/ */
-* {
+:not('panels-ipe-tray') * {
 	box-sizing: border-box;
 }
 :not('panels-ipe-tray') {

--- a/styleguide/source/assets/css/scss/generic/_reset.scss
+++ b/styleguide/source/assets/css/scss/generic/_reset.scss
@@ -6,40 +6,42 @@
 * {
 	box-sizing: border-box;
 }
-html,
-body,
-div,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-ol,
-ul,
-li,
-form,
-legend,
-label,
-table,
-header,
-footer,
-nav,
-section,
-figure {
-	margin: 0;
-	padding: 0;
-}
-header,
-footer,
-nav,
-section,
-article,
-hgroup,
-figure {
-	display: block;
+:not('panels-ipe-tray') {
+  html,
+  body,
+  div,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  ol,
+  ul,
+  li,
+  form,
+  legend,
+  label,
+  table,
+  header,
+  footer,
+  nav,
+  section,
+  figure {
+  	margin: 0;
+  	padding: 0;
+  }
+  header,
+  footer,
+  nav,
+  section,
+  article,
+  hgroup,
+  figure {
+  	display: block;
+  }
 }

--- a/styleguide/source/assets/css/scss/generic/_typography.scss
+++ b/styleguide/source/assets/css/scss/generic/_typography.scss
@@ -47,7 +47,7 @@ $bp-large: 75em; // 1200px
   font-size: $decimal-size * 1rem;
 }
 
-body {
+:not('panels-ipe-tray') body {
   /* stylelint-disable property-no-vendor-prefix */
   -webkit-text-size-adjust: 100%;
   /* stylelint-enable */


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWL-3868: Topics | Panelizer IPE Theme](https://issues.ama-assn.org/browse/EWL-3868)


## Description
Puts a lot of `:not('panels-ipe-tray')` pseudo-selectors in our "global" css to keep it from overriding Drupal's Panels IPE css. Not an especially clever or elegant fix, but seems to get the job done.


## To Test

- [x] Check out a d8 branch that has panels implemented (like **do-not-merge-panels-poc**)
- [ ] Follow d8 readme instructions for pulling in the styleguide css using drupal-deploy
  \- or -
- [x] In StyleGuide directory, run `gulp` to build the css and copy over the **assets/css/styles.css** file to the d8 **vendor/AmericanMedicalAssociation/AMA-style-guide/assets/css** folder
- [x] Create a Topic page (or another page that uses Panels)
- [x] Using the inspector, see that you're not seeing general ama_theme styles applied to Panels IPE elements

## Relevant Screenshots/GIFs

N/A

## Remaining Tasks

N/A


## Additional Notes

N/A
