### PR TITLE
Removes references to git rebase until further discussion with AMA team

### DIFF
--- a/styleguide/docs/git-workflow.md
+++ b/styleguide/docs/git-workflow.md
@@ -8,14 +8,12 @@ Emma Jane Westby has created wonderful videos and resources about using Git call
 
 ## Creating branches
 
-This project follows a git branching workflow using `feature/branchname`, `bugfix/branchname`, `hotfix/branchname`. When creating a new branch, it is helpful to base it off of `develop`. If you would like to include commits from a different branch that has not been merged, include those changes by checking out a new branch that is based on `develop`, and then use `git rebase origin/nameofbranchwithdesiredchanges`. This often works out better in the long run instead of 'chaining' feature branches off of each other directly.
+This project follows a git branching workflow using `feature/branchname`, `bugfix/branchname`, `hotfix/branchname`. When creating a new branch, it is helpful to base it off of `develop`. If you would like to include commits from a different branch that has not been merged, include those changes by checking out a new branch that is based on `develop`, and then use `git rebase origin/NameOfBranchWithDesiredChanges`. This often works out better in the long run instead of 'chaining' feature branches off of each other directly.
 
 ## Common Git Commands
 
-### Rebase or Merge?
-
-For useful flow chart on whether to `git rebase` or `git merge`, see [Rebase or Merge?](https://raw.githubusercontent.com/gitforteams/diagrams/master/flowcharts/rebase-or-merge.png).
-
 ### Pull or Fetch?
 
-In order to get upstream changes that have been merged, you can use `git fetch` followed by `git rebase`, or alternatively use `git pull`. A fetch allows you to see what has changed, and then to decide if you would like to add those changes in your branch with rebase. Use `git fetch` then `git rebase origin/branchname` to bring the branch up to date. Using `git pull` is `git fetch` followed immediately by `git merge FETCH_HEAD` in one step. In some situations, `git pull` may be suitable. Please see Rebase or Merge? above for more information.
+In order to get upstream changes that have been merged, you can use `git fetch` followed by `git merge`, or alternatively use `git pull`. A fetch allows you to see what has changed, and then to decide if you would like to add those changes in your branch with merge. Use `git fetch` then `git merge origin/branchname` to bring the branch up to date.
+
+Using `git pull` is `git fetch` followed immediately by `git merge FETCH_HEAD` in one step. In some situations, `git pull` may be suitable.


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

N/A

## Description

Edits @deadarm's previous git documentation to remove git rebase vs merge discussion for the time being. The documentation was not sufficiently clear about where rebasing should fit into our workflow and the team needs to discuss if this workflow is suitable for us without Megh being able to provide guidance on its use.

Also revises explanation of pull vs fetch since existing discussion was somewhat misleading.


## To Test

- [x] see that **docs/git-workflow.md** no longer contains section about merge vs rebase


## Relevant Screenshots/GIFs

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add?
