### PR TITLE
Feature/ewl 3941 document grid changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,17 +105,3 @@ New icons can be places in `source/assets/icons/svg`. When `gulp icons` is run, 
 We are using [Breakpoint](http://breakpoint-sass.com/) to handle media queries for responsive implementation.
 
 The first time you run `npm install` the dependency will be installed, but if you run into an error, running `npm install` again should fix the issue.
-
-### Layouts
-
-This style guide provides commonly used layouts, including one column, two column, two column heavy left (a wider left column and narrow right column), and three column layouts. The layouts are located in Molecules under Layouts and utilize flexbox.
-
-To apply a layout, first add the <code>layout</code> class to the template or page container. This class provides the 12 column structure the grid and subsequent layouts rely on. To then apply a specific layout, add that layout's <code>layout_number_up</code> class to the top level element of the pattern.
-
-For example, to use the side-by-side Two Up Layout, add the <code>layout_two_up</code> class to the top level element, then add the <code>layout_two_up-primary</code> class to the element you would like to appear in the first column, and add the <code>layout_two_up-secondary</code> class to the element you would like to appear in the second column.
-
-Note: you should not need to nest elements with class <code>.layout</code>.
-
-The <code>.layout</code> and <code>.layout_number_up</code> classes can be added to container elements both in individual patterns (i.e. organisms) and in the Twig templates that include them (e.g. templates). In general, if a specific pattern can be assumed to always use the same layout, it's fine to include the layout within that pattern.
-
-As of 8/8/17 and PR https://issues.ama-assn.org/browse/EWL-3829, use <code>.grid-region_content</code> to add consistent top margins.

--- a/styleguide/docs/code_conventions.md
+++ b/styleguide/docs/code_conventions.md
@@ -42,8 +42,43 @@ Class names and hierarchy follow the [BEM (Block Element Modifier)](http://getbe
 ### Responsive implementation using Breakpoint-Sass
 All patterns in the AMA Style Guide are fully responsive. We use [Breakpoint-Sass](http://breakpoint-sass.com/) to manage our media queries. Breakpoint is fairly simple to use and has a very thorough [wiki](https://github.com/at-import/breakpoint/wiki) explaining its useage and capabilities.
 
-### Sass-Grid
-Some of our layouts currently utilize the [Sass-grid](https://github.com/digitaledgeit/sass-grid) grid system. Sass-grid is a very lightweight, flexbox-based grid system.
+### Layouts
+
+The layouts molecules are now deprecated. To give structure to organisms and templates, please follow the grid and columns method outlined below.
+
+
+### Grids and columns
+
+#### Basics
+
+To use columns to control a template or organism's structure, start by adding an element with a `.grid` or `.container-with-grid` class (we'll get to the difference a little later). This grid instantiates a flexbox wrapper for descendant elements.
+
+Then add elements with `.col-width-x` classes, where 'x' should be replace by the number of columns you want the element to span. We use a 12 column grid, so for any given `grid` container, make sure that the `col-width-x` numbers add up to a total of 12.
+
+**Example:**
+
+```
+<a href="#" class="grid">
+  <div class="col-width-8">
+    {% include '09-text.twig' %}
+  </div>
+  <div class="col-width-4">
+    {% include '09-text.twig' %}
+  </div>
+</a>
+```
+
+The `col-width-x` classes default to `width:100%` at our mobile breakpoint (in other words, multiple columns collapse into a single-column layout). If you need to different behavior for your pattern, apply the `@grid` mixin to your named classes instead of using the `col-width-x` classes.
+
+Both the `.grid` class and the `@grid` mixin leverage [sass-grid](https://github.com/digitaledgeit/sass-grid). Sass-grid is a very lightweight, flexbox-based grid system.
+
+#### `.container` vs `.container-with-grid` vs `.grid`
+
+`.container`: has our default max-width, margins, and gutters applied. Useful for ensuring that patterns included in a template all have uniform spacing.
+
+`.grid`: has no set max-width or default gutters or margins. This just applies the flexbox class to an element.
+
+`.container-with-grid`: applies the default margins and gutters and instantiates flexbox.
 
 ### Using Placeholders
 When appropriate, please extend placeholders rather than classes:

--- a/styleguide/docs/code_conventions.md
+++ b/styleguide/docs/code_conventions.md
@@ -53,7 +53,7 @@ The layouts molecules are now deprecated. To give structure to organisms and tem
 
 To use columns to control a template or organism's structure, start by adding an element with a `.grid` or `.container-with-grid` class (we'll get to the difference a little later). This grid instantiates a flexbox wrapper for descendant elements.
 
-Then add elements with `.col-width-x` classes, where 'x' should be replaced by the number of columns you want the element to span. We use a 12 column grid, so for any given `grid` container, make sure that the `col-width-x` numbers add up to a total of 12.
+Then add elements with `.col-width-x` classes, where 'x' should be replaced by the number of columns you want the element to span. We use a 12 column grid, so for any given `.grid` container, make sure that the `.col-width-x` numbers add up to a total of 12.
 
 **Example:**
 
@@ -68,67 +68,69 @@ Then add elements with `.col-width-x` classes, where 'x' should be replaced by t
 </a>
 ```
 
-The `col-width-x` classes include default left and right padding. They default to `width:100%` at our mobile breakpoint (in other words, multiple columns collapse into a single-column layout). If you need to specify different gutters, or use a different mobile behavior for your pattern (e.g. in order to use different column widths or breakpoints), apply the `@include grid()` and `@include grid-_unit--cols(x)` mixins to your named classes* instead of using the `.grid` and `.col-width-x` classes:
+The `col-width-x` classes include default left and right padding. At our mobile breakpoint, they default to `width:100%` (in other words, multiple columns collapse into a single-column layout).
 
+If you need to specify different gutters, or use a different mobile behavior for your pattern , apply the `grid()` and the `grid__unit--cols(x)` _mixins_ to your named classes rather than using the `.grid` and `.col-width-x` _classes_.
+
+**Example:**
+
+Markup
 
 ```
-// GOOD:
 <a href="#" class="news-section">
-  <div class="news-section_text">
+  <div class="news-section_left">
     {% include '09-text.twig' %}
   </div>
-  <div class="news-section_text-other">
+  <div class="news-section_right">
     {% include '09-text.twig' %}
   </div>
 </a>
-.news-section { 
+```
+
+SCSS
+
+```
+.news-section {
   @include grid(); 
 }
-.news-section_text { 
-  @include grid-_unit-cols(8); 
+.news-section_left {
+  @include grid__unit--cols(8);
 }
-.news-section_text-other { 
-  @include grid-_unit-cols(4); 
-}
-
-.
-```
-
-
-\* note: for the sake of clarity, avoid using a `.grid` class with a `@include grid-_unit-cols(x)` mixin in a named class, or vice versa a `.column-width-x` class with an `@include grid()` parent:
-
-```
-// BAD:
-<a href="#" class="news-section">
-  <div class="col-width-8">
-    {% include '09-text.twig' %}
-  </div>
-  <div class="col-width-4">
-    {% include '09-text.twig' %}
-  </div>
-</a>
-.news-section { 
-  @include grid(); 
+.news-section_right {
+  @include grid__unit--cols(4);
 }
 ```
+
+
+**Avoid** mixing usage of the `.grid` _class_ and the `grid__unit--cols(x)` _mixin_. Similarly, do not combine the `grid()` _mixin_ with the `.col-width-x` _classes_. Parent and child elements should be consistent--use either classes **or** mixins but **not both**.
+
+**Do not do this:**
+
+Markup
+
 ```
-// ALSO BAD:
 <a href="#" class="news-section grid">
-  <div class="news-section_text">
+  <div class="news-section_right">
     {% include '09-text.twig' %}
   </div>
-  <div class="news-section_text-other">
+  <div class="news-section_left">
     {% include '09-text.twig' %}
   </div>
 </a>
-.news-section_text { 
-  @include grid-_unit-cols(8); 
+```
+
+SCSS
+
+```
+.news-section_right {
+  @include grid__unit--cols(8);
 }
-.news-section_text-other { 
-  @include grid-_unit-cols(4); 
+.news-section_left {
+  @include grid__unit--cols(4);
 }
 ```
-Both the `.grid` class and the `@grid` mixin leverage [sass-grid](https://github.com/digitaledgeit/sass-grid). Sass-grid is a very lightweight, flexbox-based grid system.
+
+**Note:** Under the hood, both the `.grid` class and the `@grid` mixin leverage [sass-grid](https://github.com/digitaledgeit/sass-grid), which is a very lightweight, flexbox-based grid system. You might want to look at how this grid works, but you should never need to work with it directly.
 
 #### `.container` vs `.container-with-grid` vs `.grid`
 

--- a/styleguide/docs/code_conventions.md
+++ b/styleguide/docs/code_conventions.md
@@ -53,7 +53,7 @@ The layouts molecules are now deprecated. To give structure to organisms and tem
 
 To use columns to control a template or organism's structure, start by adding an element with a `.grid` or `.container-with-grid` class (we'll get to the difference a little later). This grid instantiates a flexbox wrapper for descendant elements.
 
-Then add elements with `.col-width-x` classes, where 'x' should be replace by the number of columns you want the element to span. We use a 12 column grid, so for any given `grid` container, make sure that the `col-width-x` numbers add up to a total of 12.
+Then add elements with `.col-width-x` classes, where 'x' should be replaced by the number of columns you want the element to span. We use a 12 column grid, so for any given `grid` container, make sure that the `col-width-x` numbers add up to a total of 12.
 
 **Example:**
 
@@ -68,7 +68,13 @@ Then add elements with `.col-width-x` classes, where 'x' should be replace by th
 </a>
 ```
 
-The `col-width-x` classes default to `width:100%` at our mobile breakpoint (in other words, multiple columns collapse into a single-column layout). If you need to different behavior for your pattern, apply the `@grid` mixin to your named classes instead of using the `col-width-x` classes.
+The `col-width-x` classes default to `width:100%` at our mobile breakpoint (in other words, multiple columns collapse into a single-column layout). If you need to specify a different mobile behavior for your pattern (e.g. in order to use different column widths or breakpoints), apply the `@include grid()` and `@include grid-_unit--cols(x)` mixins to your named classes* instead of using the `.grid` and `.col-width-x` classes:
+
+[ block quote example here yee ]
+
+\* note: for the sake of clarity, avoid using a `.grid` class with a `@include grid-_unit-cols(x)` mixin in a named class, or vice versa a `.column-width-x` class with an `@include grid()` parent. 
+
+[ example quote here of bad example ] 
 
 Both the `.grid` class and the `@grid` mixin leverage [sass-grid](https://github.com/digitaledgeit/sass-grid). Sass-grid is a very lightweight, flexbox-based grid system.
 
@@ -79,6 +85,10 @@ Both the `.grid` class and the `@grid` mixin leverage [sass-grid](https://github
 `.grid`: has no set max-width or default gutters or margins. This just applies the flexbox class to an element.
 
 `.container-with-grid`: applies the default margins and gutters and instantiates flexbox.
+
+#### Gutters
+
+If you need to specify gutters on a certain element, use the `@include gutters()` mixin or the `$gutter` and `$gutter-mobile` responsive variables.
 
 ### Using Placeholders
 When appropriate, please extend placeholders rather than classes:

--- a/styleguide/docs/code_conventions.md
+++ b/styleguide/docs/code_conventions.md
@@ -51,7 +51,15 @@ The layouts molecules are now deprecated. To give structure to organisms and tem
 
 #### Basics
 
-To use columns to control a template or organism's structure, start by adding an element with a `.grid` or `.container-with-grid` class (we'll get to the difference a little later). This grid instantiates a flexbox wrapper for descendant elements.
+The style guide uses two primary methods for applying a [CSS Grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout): 1) using our custom `.grid` and `.col-width-x` classes or 2) using the sass mixins `grid()` and `grid__unit--cols(x)`.
+
+Under the hood, both the `.grid` class and the `@grid` mixin leverage [sass-grid](https://github.com/digitaledgeit/sass-grid), which is a very lightweight, flexbox-based grid system. Flexbox enables us to created nested, responsive grids and gives us a great deal of control over our grid elements. the `sass-grid` library makes using flexbox simple, while also allowing for graceful degradation where flexbox is not supported. When we use the classes versus using the mixins depends on the specific needs of the pattern you are creating.
+
+#### Choosing the right method
+
+##### Class Method
+
+The class method is the preferred method for adding columns to control a template or organism's structure. Start by adding an element with a `.grid` or `.container-with-grid` class (we'll get to the difference a little later). This grid instantiates a flexbox wrapper for descendant elements.
 
 Then add elements with `.col-width-x` classes, where 'x' should be replaced by the number of columns you want the element to span. We use a 12 column grid, so for any given `.grid` container, make sure that the `.col-width-x` numbers add up to a total of 12.
 
@@ -70,6 +78,7 @@ Then add elements with `.col-width-x` classes, where 'x' should be replaced by t
 
 The `col-width-x` classes include default left and right padding. At our mobile breakpoint, they default to `width:100%` (in other words, multiple columns collapse into a single-column layout).
 
+##### Mixin Method
 If you need to specify different gutters, or use a different mobile behavior for your pattern , apply the `grid()` and the `grid__unit--cols(x)` _mixins_ to your named classes rather than using the `.grid` and `.col-width-x` _classes_.
 
 **Example:**
@@ -101,7 +110,7 @@ SCSS
 }
 ```
 
-
+##### Warning!
 **Avoid** mixing usage of the `.grid` _class_ and the `grid__unit--cols(x)` _mixin_. Similarly, do not combine the `grid()` _mixin_ with the `.col-width-x` _classes_. Parent and child elements should be consistent--use either classes **or** mixins but **not both**.
 
 **Do not do this:**
@@ -129,8 +138,6 @@ SCSS
   @include grid__unit--cols(4);
 }
 ```
-
-**Note:** Under the hood, both the `.grid` class and the `@grid` mixin leverage [sass-grid](https://github.com/digitaledgeit/sass-grid), which is a very lightweight, flexbox-based grid system. You might want to look at how this grid works, but you should never need to work with it directly.
 
 #### `.container` vs `.container-with-grid` vs `.grid`
 

--- a/styleguide/docs/code_conventions.md
+++ b/styleguide/docs/code_conventions.md
@@ -68,14 +68,66 @@ Then add elements with `.col-width-x` classes, where 'x' should be replaced by t
 </a>
 ```
 
-The `col-width-x` classes default to `width:100%` at our mobile breakpoint (in other words, multiple columns collapse into a single-column layout). If you need to specify a different mobile behavior for your pattern (e.g. in order to use different column widths or breakpoints), apply the `@include grid()` and `@include grid-_unit--cols(x)` mixins to your named classes* instead of using the `.grid` and `.col-width-x` classes:
+The `col-width-x` classes include default left and right padding. They default to `width:100%` at our mobile breakpoint (in other words, multiple columns collapse into a single-column layout). If you need to specify different gutters, or use a different mobile behavior for your pattern (e.g. in order to use different column widths or breakpoints), apply the `@include grid()` and `@include grid-_unit--cols(x)` mixins to your named classes* instead of using the `.grid` and `.col-width-x` classes:
 
-[ block quote example here yee ]
 
-\* note: for the sake of clarity, avoid using a `.grid` class with a `@include grid-_unit-cols(x)` mixin in a named class, or vice versa a `.column-width-x` class with an `@include grid()` parent. 
+```
+// GOOD:
+<a href="#" class="news-section">
+  <div class="news-section_text">
+    {% include '09-text.twig' %}
+  </div>
+  <div class="news-section_text-other">
+    {% include '09-text.twig' %}
+  </div>
+</a>
+.news-section { 
+  @include grid(); 
+}
+.news-section_text { 
+  @include grid-_unit-cols(8); 
+}
+.news-section_text-other { 
+  @include grid-_unit-cols(4); 
+}
 
-[ example quote here of bad example ] 
+.
+```
 
+
+\* note: for the sake of clarity, avoid using a `.grid` class with a `@include grid-_unit-cols(x)` mixin in a named class, or vice versa a `.column-width-x` class with an `@include grid()` parent:
+
+```
+// BAD:
+<a href="#" class="news-section">
+  <div class="col-width-8">
+    {% include '09-text.twig' %}
+  </div>
+  <div class="col-width-4">
+    {% include '09-text.twig' %}
+  </div>
+</a>
+.news-section { 
+  @include grid(); 
+}
+```
+```
+// ALSO BAD:
+<a href="#" class="news-section grid">
+  <div class="news-section_text">
+    {% include '09-text.twig' %}
+  </div>
+  <div class="news-section_text-other">
+    {% include '09-text.twig' %}
+  </div>
+</a>
+.news-section_text { 
+  @include grid-_unit-cols(8); 
+}
+.news-section_text-other { 
+  @include grid-_unit-cols(4); 
+}
+```
 Both the `.grid` class and the `@grid` mixin leverage [sass-grid](https://github.com/digitaledgeit/sass-grid). Sass-grid is a very lightweight, flexbox-based grid system.
 
 #### `.container` vs `.container-with-grid` vs `.grid`


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.

**Jira Ticket**

- [EWL-3941: SG | Add basic documentation for the new grid](https://issues.ama-assn.org/browse/EWL-3941)


## Description

Moves layout documentation out of the main readme and moves it into docs/code_conventions.
Flags layouts as deprecated and outlines how the new grid and column classes should be used.


## To Test

- [x] Read the documentation
- [x] Ensure it makes sense and appears accurate


## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

This documentation could definitely be expanded, but we needed to stub something out for immediate consumption. Additional tickets can be created to flag specific details that ought to be added as time permits.


## Additional Notes

Refactoring is still in progress. If something here is inaccurate by the time this is reviewed, feel free to push a commit with fixes.