### PR TITLE
[EWL-3765] move <p>s inside the .topic_article-preview_description container

### DIFF
--- a/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/article-preview.twig
+++ b/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/article-preview.twig
@@ -2,6 +2,8 @@
     {% include 'atoms-title-label' with { 'content': 'Topic Label', 'class': 'topic_article-preview_label' } %}
     {% include "atoms-landscape-3x2" with { 'class': 'topic_article-preview_image' } %}
     {% include "molecules-link-black-h2" with { 'content': 'Article One Title', 'class': 'topic_article-preview_title' }%}
-    {% include "atoms-paragraph" with { 'class': 'topic_article-preview_description' } %}
+    <div class="topic_article-preview_description">
+      {% include "atoms-paragraph" only %}
+    </div>
     {% include "molecules-article-metadata" with { 'class': 'topic_article-preview_metadata' } %}
 </div>


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-3765: Topics | Theme News Article](https://issues.ama-assn.org/browse/EWL-3765)

## Description

While working on https://github.com/AmericanMedicalAssociation/ama-d8/pull/52 it started to become clear that the `<p>`s of `body` should be inside a `<div>` container, and that the container should have the `.topic_article-preview_description` class rather than the individual paragraphs.


## To Test

...


## Relevant Screenshots/GIFs

...


## Remaining Tasks

...


## Additional Notes

...
