### PR TITLE
[EWL-3976] : uses nth-child on grid-region_content class to correct v…

### DIFF
--- a/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/_article-preview.scss
+++ b/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/_article-preview.scss
@@ -4,12 +4,17 @@
   .topic_article-preview {
     display: flex;
     @include grid--direction-col();
+  }
+}
+
+.topic_topic-articles {
+  .topic_article-preview {
     @include gutter($margin-top-half-negative...);
   }
 }
 
 .topic_hero .topic_article-preview {
-  @include gutter($margin-top-full-negative...);
+  //@include gutter($margin-top-full-negative...);
 }
 
 // Remove inherited margins from article preview fields so that we can set consistent top margins.

--- a/styleguide/source/_patterns/03-templates/04-topic/_topic.scss
+++ b/styleguide/source/_patterns/03-templates/04-topic/_topic.scss
@@ -1,5 +1,10 @@
 // Set mobile order.
 .topic .grid-region {
+
+  .grid-region_content:not(:first-child){
+    @include gutter($padding-top-full...);
+  }
+
   // First column.
   &:nth-child(1n) {
     order: 2;

--- a/styleguide/source/_patterns/03-templates/04-topic/topic.twig
+++ b/styleguide/source/_patterns/03-templates/04-topic/topic.twig
@@ -11,7 +11,7 @@
 
   <div class="grid grid-margin">
     <aside class="topic_rail-left col-width-3 grid-region">
-      {% include 'organisms-topic-tools' %}
+      {% include 'organisms-topic-tools' with { 'class': 'grid-region_content' } %}
       {% include 'organisms-topic-promotion' with { 'class': 'grid-region_content' } %}
       {% include 'organisms-topic-topic-articles' with { 'class': 'grid-region_content' } %}
     </aside>
@@ -22,7 +22,7 @@
     </section>
 
     <aside class="topic_rail-right col-width-3 grid-region">
-      {% include 'organisms-topic-membership' %}
+      {% include 'organisms-topic-membership' with { 'class': 'grid-region_content' } %}
       {% include 'organisms-topic-related-content' with { 'class': 'grid-region_content' } %}
     </aside>
   </div>

--- a/styleguide/source/assets/css/scss/objects/_layout.scss
+++ b/styleguide/source/assets/css/scss/objects/_layout.scss
@@ -43,11 +43,6 @@
 	@include gutter($padding-top-full...);
 }
 
-// Add top margins between content within grid regions.
-.grid-region_content {
-	@include gutter($padding-top-full...);
-}
-
 // Don't add padding to the first/last children of nested grids, since the parent
 // already has padding. This is a row.
 .grid-region-nested {


### PR DESCRIPTION
…ertical spacing issues when blocks are moved around

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWL-3976: Topics | Vertical spacing of blocks on Topic Page](https://issues.ama-assn.org/browse/EWL-3976)


## Description

Removed existing gutter mixin on `.grid-region_content` class. Uses `:not(:first-child)` pseudo-selectors to add top padding as needed. Applies `.grid-region_content` class to all included patterns inside of a `.grid-region` container class.


## To Test

- [ ] Go to Templates > Topic
- [ ] See that top content (just below page title) aligns properly
- [ ] modify the `topic.twig` file and add/move around organism patterns
- [ ] See that top content (just below page title) aligns properly
- [ ] See that spacing in between patterns lower down on the page remains reasonable


## Relevant Screenshots/GIFs

N/A

## Remaining Tasks

We may need to add the `.grid-region_content` class in more places depending on how this is implemented in Drupal currently. However, I don't want to make that ticket unless/until we vet this path forward.


## Additional Notes

No.