### PR TITLE
[EWL-3977] switch from js to css implementation of Typekit

### DIFF
--- a/styleguide/source/_meta/_00-head.twig
+++ b/styleguide/source/_meta/_00-head.twig
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width" />
 
+    <link rel="stylesheet" href="https://use.typekit.net/eie0akm.css" />
     <link rel="stylesheet" href="../../assets/css/reset.css?{{ cacheBuster }}" />
     <link rel="stylesheet" href="../../assets/css/style.css?{{ cacheBuster }}" media="all" />
     <link rel="stylesheet" href="../../assets/css/pattern-scaffolding.css?{{ cacheBuster }}" media="all" />
@@ -14,9 +15,6 @@
     <script>grunticon(["../../assets/icons/icons.data.svg.css", "../../assets/icons/icons.data.png.css", "../../assets/icons/icons.fallback.css"], grunticon.svgLoadedCallback );</script>
     <noscript><link href="icons.fallback.css" rel="stylesheet"></noscript>
 
-    <!-- Typekit Font Script: Replace with Client's details -->
-    <script src="https://use.typekit.net/eie0akm.js"></script>
-    <script>try{Typekit.load({ async: true });}catch(e){}</script>
 
     <!-- Begin Pattern Lab (Required for Pattern Lab to run properly) -->
     {{ patternLabHead | raw }}


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWL-3977: SG | Change Typekit to CSS](https://issues.ama-assn.org/browse/EWL-3977)


## Description

Removes js call to Typekit. Adds css link to Typekit.


## To Test

- [x] See that the fonts are there as expected
- [x] Look in the header and see that we load Typekit by css rather than js now.


## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

No.


## Additional Notes
No.
