### PR TITLE
[EWL-3974] : adds specified line height to topics hero h2

### DIFF
--- a/styleguide/source/_patterns/02-organisms/06-topic/01-topic-hero/_topic-hero.scss
+++ b/styleguide/source/_patterns/02-organisms/06-topic/01-topic-hero/_topic-hero.scss
@@ -45,5 +45,5 @@
 .topic_hero h2.topic_article-preview_title {
   display: inline-block;
   vertical-align: sub;
-  line-height: 0.55em;
+  line-height: 1.11765;
 }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWL-3974: Topics | CSS line height for Topic hero title](https://issues.ama-assn.org/browse/EWL-3974)


## Description

Adds css specified in the ticket


## To Test

- [ ] Organisms > Topic > Topic Hero Section

Inspect title and see the line height is 1.11765


## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

N/A


## Additional Notes

N/A
