### PR TITLE
Run release in single sequence because gulp is annoying.

### DIFF
--- a/styleguide/gulpfile.js
+++ b/styleguide/gulpfile.js
@@ -304,14 +304,20 @@ gulp.task('tag', function () {
     .pipe(shell(['git push origin --tags']));
 });
 
+gulp.task('set-master', function (callback) {
+  // Change the deploy branch
+  gutil.log('Setting branch to master.');
+  config.deployment.branch = "master";
+  callback();
+})
+
 // Task: Release the code
 // Description: Release runs deploy to build to gh-pages,
 // pushes the same code to master, then tags master.
-gulp.task('release', function () {
+gulp.task('release', function (callback) {
   // make sure to use the gulp from node_modules and not a different version
   runSequence = require('run-sequence').use(gulp);
-  // Change the deploy branch
-  config.deployment.branch = "master";
-  // publish to gh-pages and master then tag master.
-  runSequence('default', 'publish', 'tag');
+  // Build the style guide, publish to gh-pages, set the branch to master,
+  // publish to master, then tag master.
+  runSequence('default', 'publish', 'set-master', 'publish', 'tag', callback);
 });


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.

**Github Issue**

NA

**Jira Ticket**

NA

## Description

Follow up to #213, which didn't actually work as expected. Since gulp wants to run everything asynchronously all the time ever which is super annoying, we have to combine what was going on in `gulp release` into a single `runSequence` command (also prob because my gulp-ing is bad). I've tested and this works now.

## To Test

- Be sure the last commit in your branch (before the gulp changes) is https://github.com/AmericanMedicalAssociation/AMA-style-guide/commit/e2350cb04a0daf37054e91f84dfa4cbd81a422f7
- Run `gulp release`
- Observe a commit to `gh-pages` and then one soon after to `master`.
- Tagging will fail since you didn't update the tag in composer.json, this is correct.


## Relevant Screenshots/GIFs

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add?
