### PR TITLE
Feature/ewl 3993 tools spacing

### DIFF
--- a/styleguide/source/_patterns/02-organisms/06-topic/02-topic-tools/_topic-tools.scss
+++ b/styleguide/source/_patterns/02-organisms/06-topic/02-topic-tools/_topic-tools.scss
@@ -1,8 +1,11 @@
 .ama-theme {
-
   // The tools block.
   .topic_tools {
     max-width: 800px;
+
+    ul li {
+      margin-bottom: 0; // override default list styles
+    }
 
     // Tools links.
     .tools_list-learn-more {

--- a/styleguide/source/_patterns/02-organisms/06-topic/02-topic-tools/_topic-tools.scss
+++ b/styleguide/source/_patterns/02-organisms/06-topic/02-topic-tools/_topic-tools.scss
@@ -1,7 +1,4 @@
 .ama-theme {
-  .layout.topic_tools {
-    @include grid--direction-col();
-  }
 
   // The tools block.
   .topic_tools {


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWL-3993: Topics | Even out vertical padding on Tools items](https://issues.ama-assn.org/browse/EWL-3993)


## Description

Overrides some default list styles that were making the tools list look wonky.


## To Test

- [x] Go to Templates > Topics
- [x] Go to Organisms > Topics > Tools
- [ ] see that the amount of space between elements is fairly even (specifically for tablet and below)

## Relevant Screenshots/GIFs

![screen-shot-2017-09-27-at-2 50 22-pm](https://user-images.githubusercontent.com/28711067/30935396-29f3dbfc-a396-11e7-8a7b-47760872d942.jpg)


## Remaining Tasks
None


## Additional Notes

No
