### PR TITLE
[EWL-4007] : removes related content with image pattern...

### DIFF
--- a/styleguide/source/_patterns/01-molecules/06-components/24-topic-related-content/_topic-related-content.scss
+++ b/styleguide/source/_patterns/01-molecules/06-components/24-topic-related-content/_topic-related-content.scss
@@ -5,11 +5,6 @@
     padding-right: 0;  //override default gutters
   }
 
-  .topic-related-content img {
-    max-height: 180px; // arbitrary max-height so images aren't huge on mobile
-    display: inline-block;
-  }
-
   .topic-related-content_title {
     margin-bottom: 0;
     @include type($font-serif, 21px, $font-weight-medium, 1.3333333333);

--- a/styleguide/source/_patterns/01-molecules/06-components/24-topic-related-content/topic-related-content.md
+++ b/styleguide/source/_patterns/01-molecules/06-components/24-topic-related-content/topic-related-content.md
@@ -3,6 +3,6 @@ el: ".topic-related-content"
 title: "Topic Related Content"
 ---
 
-The topic related content shows topic content title, link, and, in the topic-related-content-with-image variant, an image.
+The topic related content shows topic content title and link.
 
 [EWL-3771](https://issues.ama-assn.org/browse/EWL-3771)

--- a/styleguide/source/_patterns/01-molecules/06-components/24-topic-related-content/topic-related-content.twig
+++ b/styleguide/source/_patterns/01-molecules/06-components/24-topic-related-content/topic-related-content.twig
@@ -1,14 +1,3 @@
-{% set applyGrid = related_content.image ? "grid" : "" %}
-<div class="topic-related-content {{applyGrid}}">
-  {% if related_content.image %}
-    <div class="col-width-6">
-      {% include 'atoms-landscape-3x2' with { 'src': related_content.image } %}
-    </div>
-    <div class="col-width-3">
-      {% include 'atoms-h2' with { 'content': related_content.title, 'class': 'topic-related-content_title' } %}
-      {% include 'atoms-link-blue' with { 'content': 'Sed nuc', 'class': 'topic-related-content_link' } %}
-    </div>
-  {% else %}
-    {% include 'atoms-h2' with { 'content': related_content.title, 'class': 'topic-related-content_title' } %}{% include 'atoms-link-blue' with { 'content': 'Link text', 'class': 'topic-related-content_link' } %}
-  {% endif %}
+<div class="topic-related-content">
+  {% include 'atoms-h2' with { 'content': related_content.title, 'class': 'topic-related-content_title' } %}{% include 'atoms-link-blue' with { 'content': 'Link text', 'class': 'topic-related-content_link' } %}
 </div>

--- a/styleguide/source/_patterns/01-molecules/06-components/24-topic-related-content/topic-related-content~with-image.json
+++ b/styleguide/source/_patterns/01-molecules/06-components/24-topic-related-content/topic-related-content~with-image.json
@@ -1,6 +1,0 @@
-{
-  "related_content": {
-      "title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-      "image": "https://ipsumimage.appspot.com/279x186?l=3:2|279x186&s=36"
-    }
-}

--- a/styleguide/source/_patterns/02-organisms/06-topic/09-topic-related-content-list/topic-related-content-list.json
+++ b/styleguide/source/_patterns/02-organisms/06-topic/09-topic-related-content-list/topic-related-content-list.json
@@ -4,14 +4,9 @@
       "title": "Lorem ipsum dolor inside a topics page"
     },
     "second":{
-      "title": "Lorem ipsum",
-      "image": "https://ipsumimage.appspot.com/279x186?l=3:2|279x186&s=36"
+      "title": "Lorem ipsum"
     },
     "third":{
-      "title": "Lorem ipsum dolor sit amet. Consectetur adipiscing elit",
-      "image": "https://ipsumimage.appspot.com/279x186?l=3:2|279x186&s=36"
-    },
-    "fourth":{
       "title": "Lorem ipsum dolor sit amet. Consectetur adipiscing elit"
     }
   }

--- a/styleguide/source/_patterns/02-organisms/06-topic/09-topic-related-content-list/topic-related-content-list.twig
+++ b/styleguide/source/_patterns/02-organisms/06-topic/09-topic-related-content-list/topic-related-content-list.twig
@@ -4,6 +4,5 @@
     <li>{% include 'molecules-topic-related-content' with { 'related_content' : related_content_list.first} %}</li>
     <li>{% include 'molecules-topic-related-content' with { 'related_content' : related_content_list.second} %}</li>
     <li>{% include 'molecules-topic-related-content' with { 'related_content' : related_content_list.third} %}</li>
-    <li>{% include 'molecules-topic-related-content' with { 'related_content' : related_content_list.fourth} %}</li>
   </ul>
 </div>


### PR DESCRIPTION
… and pretends it never existed

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWL-4007: Remove - related content with image from D8 and Style Guide ](https://issues.ama-assn.org/browse/EWL-4007)


## Description

Removes the related content with image pattern


## To Test

- [x] In the menu Molecules > Components > Topic Related Content should be present but not a Topic Related Content With Image variant
- [x] You should not see files for this variant in the code
- [x] You should not see scss for this variant
- [x] Organisms > Topics > Topic Related Content List should look appropriately styled


## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

This ticket also covers Drupal work so please make a comment but don't move this ticket to testing after merging.


## Additional Notes

Anything more to add?
