### PR TITLE
[EWL-3996] : adds mobile styles for hiding the topic label

### DIFF
--- a/styleguide/source/_patterns/02-organisms/06-topic/01-topic-hero/_topic-hero.scss
+++ b/styleguide/source/_patterns/02-organisms/06-topic/01-topic-hero/_topic-hero.scss
@@ -2,6 +2,18 @@
   @include gutter($padding-top-full...);
 }
 
+.topic_hero .topic_article-preview_label {
+  @include breakpoint(0 $bp-small) {
+    display: none;
+  }
+}
+
+.topic_hero .topic_article-preview_container-title {
+  @include breakpoint(0 $bp-small) {
+    margin-top: 0;
+  }
+}
+
 .topic_hero .topic_article-preview_title {
   display: inline-block;
   @include type($font-serif, 24px, $font-weight-medium, 1.3043478261);


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWL-3996: Topics | SG | ENHANCEMENT | Hide "Topic Labels" on mobile in Article Hero block.](https://issues.ama-assn.org/browse/EWL-3996)


## Description
Adds a display: none and removes excess top margin when breakpoint is between 0 and our tablet breakpoint.


## To Test

- [ ] Review pattern organisms-topic-hero both alone and in the context of the topic template
- [ ] see that it behaves as requested in the Jira ticket


## Relevant Screenshots/GIFs

Before
![screen shot 2017-10-03 at 2 13 52 pm](https://user-images.githubusercontent.com/28711067/31144302-f4866a3e-a845-11e7-8c1c-c881f39c7fb7.png)

After
![screen shot 2017-10-03 at 2 13 32 pm](https://user-images.githubusercontent.com/28711067/31144307-f6988be0-a845-11e7-96c3-8f43621be53b.png)

## Remaining Tasks

No


## Additional Notes
No
