### PR TITLE
refs EWL-4017: ensure that order is always media, title then description

### DIFF
--- a/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/article-preview.twig
+++ b/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/article-preview.twig
@@ -17,12 +17,9 @@
       {% endif %}
     {% endif %}
     {% if topic_article.video %}
-      <div class="topic_article-preview_container-title"> {% include "molecules-link-black-h2" with { 'class': 'topic_article-preview_title', 'content': topic_article.title }%}</div>
       {% include "atoms-video-youtube" with {'class': 'topic_article-preview_video'} %}
     {% endif %}
-    {% if not topic_article.video %}
-      <div class="topic_article-preview_container-title"> {% include "molecules-link-black-h2" with { 'class': 'topic_article-preview_title', 'content': topic_article.title }%}</div>
-    {% endif %}
+    <div class="topic_article-preview_container-title"> {% include "molecules-link-black-h2" with { 'class': 'topic_article-preview_title', 'content': topic_article.title }%}</div>
     {% if not topic_article.related %}
       <div class="topic_article-preview_description">
         {% include "atoms-paragraph" with {'content' : topic_article.description} only %}


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)
**JIRA ticket**
* [EWL-4017: Topics | Reorder components in Hero](https://issues.ama-assn.org/browse/EWL-4017)

## Description
Update the article-preview.twig file so the order for the elements is always as follows:
1. Media (image or video)
2. Title
3. Description


## To Test
- [x] Review the Article Preview Molecule (Molecules > Components > Article Preview) 
- [x] Observe that the order of elements is Image, Title, Description
- [x] Review the Article Preview Video Molecule (Molecules > Components > Article Preview Video)
- [x] Observe that the order of elements is Image, Title, Description


## Relevant Screenshots/GIFs
**Before**
<img width="744" alt="screen shot 2017-10-09 at 2 01 16 pm" src="https://user-images.githubusercontent.com/1653723/31354032-6a143a0c-acfa-11e7-9d1c-334421ee75f1.png">

-----

**After***
<img width="745" alt="screen shot 2017-10-09 at 2 00 21 pm" src="https://user-images.githubusercontent.com/1653723/31354058-7c3d07c2-acfa-11e7-9d89-c0b5ffda3935.png">

## Remaining Tasks
N/A

## Additional Notes
N/A
