### PR TITLE
refs EWL-4005: update to docs about newline and coding standards

### DIFF
--- a/docs/code_conventions.md
+++ b/docs/code_conventions.md
@@ -7,6 +7,7 @@
   - [Use You Some JSON](#use-you-some-json)
   - [Pseudo-Patterns](#pseudo-patterns)
   - [Pattern Lab reserved words](#pattern-lab-reserved-words)
+  - [Twig Coding standards](#twig-coding-standards)
 - [HTML](#html)
   - [Semantic Markup](#semantic-markup)
   - [Aria Tags and Accessibility](#aria-tags-and-accessibility)
@@ -165,6 +166,10 @@ In general, you can create any number of variables within your templates to use 
 <li>{% include 'atoms-logo' with {'link': 'http://example.com' } %}</li>
                                    ----
 ```
+
+### Twig Coding Standards
+
+All twig files should follow the standards and procedures set out in [Drupal Twig Coding Standards](https://www.drupal.org/docs/develop/coding-standards/twig-coding-standards) and [Git coding standards](https://github.com/git/git/blob/master/Documentation/CodingGuidelines). Including but not limited to newline at the end of files.
 
 ## HTML
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.

**Github Issue**

- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**

- [EWL-4005: SPIKE Define line ending standards for Twig](https://issues.ama-assn.org/browse/EWL-4005)


## Description
Define what the coding standard will be for newlines at the end of Twig files: we will use newlines at the end of Twig files. And decide on a remediation strategy for the current Twig files: we will not be remediating current Twig files, but we should be adding a newline at then end of Twig files going forward.

## To Test

- [ ] Review the docs in styleguide
- [ ] Observe you see a new section for [Twig Coding Standards](https://github.com/AmericanMedicalAssociation/AMA-style-guide/blob/feature/EWL-4005-line-endings-doc/docs/code_conventions.md#twig-coding-standards)
- [ ] Observe that it mentions having a newline at the end of Twig files


## Relevant Screenshots/GIFs

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add?
