### PR TITLE
[EWL-4110] Topics | Clean up tools text wrap

### DIFF
--- a/styleguide/source/_patterns/01-molecules/08-lists/12-list-topic-tools/_list-topic-tools.scss
+++ b/styleguide/source/_patterns/01-molecules/08-lists/12-list-topic-tools/_list-topic-tools.scss
@@ -53,13 +53,17 @@
     .list_topic-tools_icon {
       display: none;
       float: left;
-      height: 40px;
       margin-right: 14px;
       vertical-align: -webkit-baseline-middle;
       width: 40px;
 
       @include breakpoint($bp-med) {
         display: block;
+        height: 64px; // increase the icon height so the file type doesn't wrap under it when the text content is longer.
+      }
+
+      @include breakpoint($bp-large) {
+        height: 50px;
       }
     }
 

--- a/styleguide/source/_patterns/01-molecules/08-lists/12-list-topic-tools/list-topic-tools.json
+++ b/styleguide/source/_patterns/01-molecules/08-lists/12-list-topic-tools/list-topic-tools.json
@@ -6,7 +6,7 @@
       "size": "2MB"
     },
     "second": {
-      "title": "Consectetur adipiscing elit",
+      "title": "Consectetur adipiscing elit, this title is two lines long",
       "type": "mpeg",
       "size": "1MB"
     },


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-4110: Topics | Clean up tools text wrap](https://issues.ama-assn.org/browse/EWL-4110)


## Description

Adjusts the height of the icon in the Tools block so that two-line text wraps more cleanly.


## To Test

- [ ] Templates > Topic > observe that the second item in the Tools block list is two lines long and that the text and file type wrap evenly
- [ ] Resize the page to different breakpoints and make sure it still looks okay


## Relevant Screenshots/GIFs
before:
![before](https://user-images.githubusercontent.com/12160398/32016428-90140c14-b989-11e7-8140-75a3f26e9e5e.png)
after:
![after](https://user-images.githubusercontent.com/12160398/32016427-9007371e-b989-11e7-8a26-f4bb54c0facc.png)



## Remaining Tasks

- [x] add character limit suggestion to the d8 field ("<75 chars")


## Additional Notes

In order to support more than two lines of tool text this pattern would probably need to be refactored. Workaround per convo with @froboy is to suggest a character limit in the field help text.
