### PR TITLE
[EWL-3809] Fix footer in IE11

### DIFF
--- a/styleguide/source/assets/css/scss/objects/_layout.scss
+++ b/styleguide/source/assets/css/scss/objects/_layout.scss
@@ -113,6 +113,7 @@
 }
 
 .col-width-12 {
+	width: 100%;
 	@include grid__unit--cols(12);
 	@include gutter($padding-right-half...);
 	@include gutter($padding-left-half...);


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-3809: Topics | Theme Footer](https://issues.ama-assn.org/browse/EWL-3809)


## Description

- adds `width: 100%;` to `.col-width-12` grid class because IE11 doesn't respect nested flexbox elements sometimes. See https://github.com/philipwalton/flexbugs/issues/104


## To Test

- [ ] Templates > Topic - see that the footer looks correct in IE11


## Relevant Screenshots/GIFs

Before:
![3809-before](https://user-images.githubusercontent.com/12160398/32066161-8ab179c6-ba44-11e7-84ff-b607cd43d455.png)
After:
![3809-after](https://user-images.githubusercontent.com/12160398/32066163-8beb8e4e-ba44-11e7-8296-938cb2a35a1b.png)


## Remaining Tasks

- this will need to be deployed to `dev-assets` and consumed by d8 before it can be tested/pass in d8.


## Additional Notes

Found some other broken things (header, page container) and am following up about fixing those as separate tickets with Gwen.
