### PR TITLE
[EWL-3792] Topics | Build Ribbon Header

### DIFF
--- a/styleguide/source/_patterns/01-molecules/05-navigation/08-ribbon-user-menu/_ribbon-user-menu.scss
+++ b/styleguide/source/_patterns/01-molecules/05-navigation/08-ribbon-user-menu/_ribbon-user-menu.scss
@@ -7,7 +7,7 @@
     width: 35px;
 
     @include breakpoint(740px) {
-      width: 367px;
+      width: 370px;
     }
   }
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-3792: Topics | Build Ribbon Header](https://issues.ama-assn.org/browse/EWL-3792)


## Description

Bumped up the width of the User Menu element by a few pixels. For some reason IE11 didn't think the menu was wide enough. May have to do with subpixel rendering? Anyway, it works now... 


## To Test

- [ ] Templates > Topic - view in IE11, make sure it looks correct and not broken


## Relevant Screenshots/GIFs
Before:
![3792-before](https://user-images.githubusercontent.com/12160398/32075403-58445ba2-ba62-11e7-9e73-f81a5627da2d.png)
After:
![3792-after](https://user-images.githubusercontent.com/12160398/32075402-5835b9a8-ba62-11e7-8a64-c343bdc1c85a.png)



## Remaining Tasks

- this needs to be deployed to `dev-assets` and consumed by drupal before this can be tested in d8.


## Additional Notes

N/A
