### PR TITLE
[EWL-3951] Topics | fix "bookend" layout in IE11

### DIFF
--- a/styleguide/source/_patterns/03-templates/04-topic/_topic.scss
+++ b/styleguide/source/_patterns/03-templates/04-topic/_topic.scss
@@ -1,3 +1,8 @@
+// Bugfix - IE11 doesn't rendering this <div> as block-level, so set it here to preserve the layout.
+.topic {
+  display: block;
+}
+
 // Set mobile order.
 .topic .grid-region {
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-3951: Topics | Theme "bookend" layout](https://issues.ama-assn.org/browse/EWL-3951)


## Description

Adds `display: block;` to the `.topic` page container in to fix a display bug in IE11. 

For some reason IE11 wasn't rendering`div.topic` as block-level despite this being a standard of how the DOM works... probably something to do with Flexbox and inheritance (I couldn't find a specific example of this bug happening elsewhere but there are [related reports on SO having to do with ancestry](https://stackoverflow.com/questions/44243712/ie11-css-display-inline-block-overflowing-inside-flexbox)) 

## To Test

- [ ] Templates > Topic: observe that the page content (title and block content) appears to be in proper alignment


## Relevant Screenshots/GIFs
Before:
![3951-before](https://user-images.githubusercontent.com/12160398/32185077-3219dca6-bd6c-11e7-8352-8f17e5ad2273.png)
After:
![3951-after](https://user-images.githubusercontent.com/12160398/32185078-3224625c-bd6c-11e7-8e2f-766cc1d57ffc.png)

## Remaining Tasks

This will need to be deployed to `dev-assets` and consumed by d8 before the changes can be tested in Drupal. 


## Additional Notes

N/A
