### PR TITLE
[EWL-4022] SG | Remove ".topic_bottom" region from Topic template

### DIFF
--- a/styleguide/source/_patterns/03-templates/04-topic/topic.twig
+++ b/styleguide/source/_patterns/03-templates/04-topic/topic.twig
@@ -26,10 +26,6 @@
       {% include 'organisms-topic-related-content-list' with { 'class': 'grid-region_content' } %}
     </aside>
   </div>
-  <div class="grid grid-margin">
-    <div class="topic_bottom col-width-12 grid-region">
-    </div>
-  </div>
 </main>
 
 {% include 'organisms-footer' %}


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-4022: SG | Remove ".topic_bottom" region from Topic template](https://issues.ama-assn.org/browse/EWL-4022)


## Description
Removes the `.topic_bottom` region from the template as it isn't being used.


## To Test

- [ ] Templates > Topic - verify that `.topic_bottom` is not there 


## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

N/A

## Additional Notes

This has no d8 implications - it's just cleanup.
