### PR TITLE
[EWL-4139] Bug - topic page text is only going to 50% width on mobile

### DIFF
--- a/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/_article-preview.scss
+++ b/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/_article-preview.scss
@@ -51,7 +51,7 @@
     }
   }
 
-  .topic_article-preview_container-title {
+  .topic_article-preview_container-image + .topic_article-preview_container-title {
     @include grid__unit--cols(6);
     order: 1;
 


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-4139: Bug - topic page text is only going to 50% width on mobile](https://issues.ama-assn.org/browse/EWL-4139)


## Description

- Adds a sibling selector to the Related Articles block list items so that if there's no image, the text will span full width.


## To Test

- [ ] Templates > Topic
- [ ] Edit `topic.twig` and place a Related Articles block in the right sidebar
- [ ] Using the inspector, remove the image div `.topic_article-preview_container-image` and observe that the text in `.topic_article-preview_container-title` flows to the full width of its container
- [ ] Resize the viewport to mobile/tablet and make sure the block still displays apporpriately
- [ ] Make sure the existing Related Articles block with images still looks alright 


## Relevant Screenshots/GIFs
Deleting the image from the block on mobile
![4139-1](https://user-images.githubusercontent.com/12160398/32336870-7bcdc642-bfbe-11e7-8cf4-bbad06f32658.gif)



## Remaining Tasks

This needs to be released via `gulp-deploy` and consumed by d8 before it can be tested there.

## Additional Notes

N/A
