### PR TITLE
Bugfix: EWL-3937 Regression in search icon

### DIFF
--- a/styleguide/source/_patterns/00-atoms/06-buttons/01-button-search/_button-search.scss
+++ b/styleguide/source/_patterns/00-atoms/06-buttons/01-button-search/_button-search.scss
@@ -40,10 +40,7 @@
     position: absolute;
     right: 5px;
     top: 10px;
-
-    svg {
-      height: 20px;
-      width: 20px;
-    }
+    height: 20px;
+    width: 20px;
   }
 }

--- a/styleguide/source/_patterns/00-atoms/09-icons/05-search.twig
+++ b/styleguide/source/_patterns/00-atoms/09-icons/05-search.twig
@@ -1,1 +1,1 @@
-<span class="icon icon-search" data-grunticon-embed></span>
+<span class="icon icon-search"></span>


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.

**Jira Ticket**

- https://issues.ama-assn.org/browse/EWL-3937


## Description
Removes data-grunticon-embed class because it overrides the search icon background image.


## To Test

- [x] http://localhost:3000/?p=viewall-templates-all
- [x] Verify that the search icon is blue not orange

## Relevant Screenshots/GIFs
![screen shot 2017-11-09 at 4 16 50 pm](https://user-images.githubusercontent.com/2271747/32753091-3763f734-c891-11e7-82c5-5a73cdc42004.png)
![screen shot 2017-11-10 at 12 53 12 pm](https://user-images.githubusercontent.com/2271747/32753092-376d80c4-c891-11e7-8316-354033833a78.png)
