### PR TITLE
EWL-4231: Refactor small related articles remove LI

### DIFF
--- a/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/_article-preview.scss
+++ b/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/_article-preview.scss
@@ -71,38 +71,40 @@
   flex-direction: row;
 }
 
-.topic_article-preview-small .topic_article-preview_label,
-.topic_article-preview-small .topic_article-preview_container-title,
-.topic_article-preview-small .topic_article-preview_metadata {
-  @include grid__unit--cols(12);
-}
+aside .topic_article-preview-small {
+  .topic_article-preview_label,
+  .topic_article-preview_container-title,
+  .topic_article-preview_metadata {
+    @include grid__unit--cols(12);
+  }
 
-.topic_article-preview-small .topic_article-preview_container-image {
-  @include grid__unit--cols(5);
-}
+  .topic_article-preview_container-image {
+    @include grid__unit--cols(5);
+  }
 
-.topic_article-preview-small .topic_article-preview_description {
-  @include grid__unit--cols(7);
-  @include gutter($padding-right-half...);
-}
+  .topic_article-preview_description {
+    @include grid__unit--cols(7);
+    @include gutter($padding-right-half...);
+  }
 
-.topic_article-preview-small .topic_article-preview_label {
-  order: 1;
-  margin-bottom: 0;
-}
+  .topic_article-preview_label {
+    order: 1;
+    margin-bottom: 0;
+  }
 
-.topic_article-preview-small .topic_article-preview_container-title {
-  order: 2;
-}
+  .topic_article-preview_container-title {
+    order: 2;
+  }
 
-.topic_article-preview-small .topic_article-preview_description {
-  order: 3;
-}
+  .topic_article-preview_description {
+    order: 3;
+  }
 
-.topic_article-preview-small .topic_article-preview_container-image {
-  order: 4;
-}
+  .topic_article-preview_container-image {
+    order: 4;
+  }
 
-.topic_article-preview-small .topic_article-preview_metadata {
-  order: 5;
+  .topic_article-preview_metadata {
+    order: 5;
+  }
 }

--- a/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/article-preview.twig
+++ b/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/article-preview.twig
@@ -5,7 +5,7 @@
   topic_article.small ? "topic_article-preview-small"
 ] %}
 
-<div class="topic_article-preview {{ classes|join(' ') }} {{ class }}">
+<article class="topic_article-preview {{ classes|join(' ') }} {{ class }}">
     {% if topic_article.label %}
       {% include 'atoms-title-label' with { 'content': 'Topic Label', 'class': 'topic_article-preview_label' } %}
     {% endif %}
@@ -26,4 +26,4 @@
       </div>
       {% include "molecules-article-metadata" with { 'class': 'topic_article-preview_metadata' } %}
     {% endif %}
-</div>
+</article>

--- a/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/article-preview.twig
+++ b/styleguide/source/_patterns/01-molecules/06-components/22-article-preview/article-preview.twig
@@ -5,7 +5,7 @@
   topic_article.small ? "topic_article-preview-small"
 ] %}
 
-<article class="topic_article-preview {{ classes|join(' ') }} {{ class }}">
+<div class="topic_article-preview {{ classes|join(' ') }} {{ class }}">
     {% if topic_article.label %}
       {% include 'atoms-title-label' with { 'content': 'Topic Label', 'class': 'topic_article-preview_label' } %}
     {% endif %}
@@ -26,4 +26,4 @@
       </div>
       {% include "molecules-article-metadata" with { 'class': 'topic_article-preview_metadata' } %}
     {% endif %}
-</article>
+</div>

--- a/styleguide/source/_patterns/01-molecules/08-lists/14-list-topic-related-articles/_list-topic-related-articles.scss
+++ b/styleguide/source/_patterns/01-molecules/08-lists/14-list-topic-related-articles/_list-topic-related-articles.scss
@@ -1,25 +1,16 @@
-.ama-theme {
-  .list_topic-related-articles {
-    list-style: none;
-    margin: 0;
-    max-width: $max-width;
-    padding: 0;
+.ama__list-topic-related-article {
+  @include gutter($padding-top-half...);
+  @include gutter($padding-bottom-half...);
+  margin-bottom: 0;
 
-    .list_item-topic-related-article {
-      @include gutter($padding-top-half...);
-      @include gutter($padding-bottom-half...);
-      margin-bottom: 0;
+  &:not(:first-of-type) {
+    @include rule-horizontal(1px, $black-20, solid);
+  }
 
-      &:not(:first-child) {
-        @include rule-horizontal(1px, $black-20, solid);
-      }
-    }
-
-    a {
-      @extend %text-transition;
-      &:hover {
-        color: $blue;
-      }
+  a {
+    @extend %text-transition;
+    &:hover {
+      color: $blue;
     }
   }
-} // closes .ama-theme
+}

--- a/styleguide/source/_patterns/01-molecules/08-lists/14-list-topic-related-articles/list-topic-related-articles.json
+++ b/styleguide/source/_patterns/01-molecules/08-lists/14-list-topic-related-articles/list-topic-related-articles.json
@@ -1,19 +1,16 @@
 {
-  "listTopicRelatedArticles": {
-    "first": {
+  "listTopicRelatedArticles":
+    [{
       "title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
       "related": true,
       "image": "https://ipsumimage.appspot.com/140x100?l=7:5|140x100&amp;s=18"
-    },
-    "second": {
+    },{
       "title": "Consectetur adipiscing elit",
       "related": true,
       "image": ""
-    },
-    "third": {
+    },{
       "title": "Lorem ipsum dolor sit amet, dictum dui, massa erat morbi facilisis",
       "related": true,
       "image": "https://ipsumimage.appspot.com/140x100?l=7:5|140x100&amp;s=18"
-    }
-  }
+    }]
 }

--- a/styleguide/source/_patterns/01-molecules/08-lists/14-list-topic-related-articles/list-topic-related-articles.twig
+++ b/styleguide/source/_patterns/01-molecules/08-lists/14-list-topic-related-articles/list-topic-related-articles.twig
@@ -1,5 +1,4 @@
-<ul class="list_topic-related-articles">
-  <li class="list_item-topic-related-article">{% include 'molecules-article-preview' with { 'topic_article': listTopicRelatedArticles.first } %}</li>
-  <li class="list_item-topic-related-article">{% include 'molecules-article-preview' with { 'topic_article': listTopicRelatedArticles.second } %}</li>
-  <li class="list_item-topic-related-article">{% include 'molecules-article-preview' with { 'topic_article': listTopicRelatedArticles.third } %}</li>
-</ul>
+{% for article in listTopicRelatedArticles %}
+  {% set topic_article = article %}
+  <article role="article" class="ama__list-topic-related-article">{% include '@molecules/06-components/22-article-preview/article-preview.twig' %}</article>
+{% endfor %}


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.

**Jira Ticket**

- https://issues.ama-assn.org/browse/EWL-4231


## Description
Remove `<LI>` in favor of markup we can use on the Drupal side -- We need to be able to use multiple "View Modes" in one section. On the Drupal side, when using this with other View Modes we were getting `<li>` without a parent `<ul>`.


## To Test

- [ ] View http://localhost:3000/?p=templates-topic
- [ ] Verify that the `<li>`(s) have been removed and everything looks and functions right at all breakpoints. This is for the small related article.


## Relevant Screenshots/GIFs
![screen shot 2017-11-10 at 1 31 55 pm](https://user-images.githubusercontent.com/231467/32673060-8846e878-c61b-11e7-84b8-a9e6b17e957f.png)



## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add?
