### PR TITLE
[EWL-4030] Wayfinder front end

### DIFF
--- a/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/_link-with-back-icon.scss
+++ b/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/_link-with-back-icon.scss
@@ -7,11 +7,10 @@
   align-self: center;
 }
 
-.link-back_text {
-  padding-left: 4px; // add some visual breathing room between the icon and the text.
-}
-
-.link-back .icon-select {
+.link-back_icon .icon-select {
   transform: rotate(90deg) translateY(-4px) translateX(7px); // adjust the positioning of the icon so it lines up with the text and the container edge.
 }
 
+.link-back_text {
+  padding-left: 4px; // add some visual breathing room between the icon and the text.
+}

--- a/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/_link-with-back-icon.scss
+++ b/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/_link-with-back-icon.scss
@@ -1,0 +1,17 @@
+.link-back {
+  display: flex;
+  font-size: 0.9em;
+}
+
+.link-back_icon {
+  align-self: center;
+}
+
+.link-back_text {
+  padding-left: 4px; // add some visual breathing room between the icon and the text.
+}
+
+.link-back .icon-select {
+  transform: rotate(90deg) translateY(-4px); // adjust the positioning of the icon so it lines up with the container edge.
+}
+

--- a/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/_link-with-back-icon.scss
+++ b/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/_link-with-back-icon.scss
@@ -12,6 +12,6 @@
 }
 
 .link-back .icon-select {
-  transform: rotate(90deg) translateY(-4px); // adjust the positioning of the icon so it lines up with the container edge.
+  transform: rotate(90deg) translateY(-4px) translateX(7px); // adjust the positioning of the icon so it lines up with the text and the container edge.
 }
 

--- a/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/link-with-back-icon.json
+++ b/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/link-with-back-icon.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://www.google.com",
+  "content": "Link text"
+}

--- a/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/link-with-back-icon.md
+++ b/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/link-with-back-icon.md
@@ -1,0 +1,6 @@
+---
+title: 'Link with "Back" Icon'
+---
+A link with a "back" icon visually prepended.
+
+Added as part of [EWL-4030](https://issues.ama-assn.org/browse/EWL-4030)

--- a/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/link-with-back-icon.twig
+++ b/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/link-with-back-icon.twig
@@ -1,0 +1,8 @@
+<a href="{{ url }}" class="link-back">
+  <span class="link-back_icon">
+    {% include 'atoms-arrow-select' %}
+  </span>
+  <span class="link-back_text">
+    {{ content }}
+  </span>
+</a>

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
@@ -7,8 +7,8 @@
   display: flex;
 }
 
-.wayfinder .logo-outer {
-  margin: 28px auto;
+.wayfinder_logo .logo-outer {
+  margin: $gutter auto;
   align-self: center;
 }
 

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
@@ -2,7 +2,17 @@
   border-bottom: solid 1px $gray-8;
 }
 
-.wayfinder .logo {
-  display: block;
-  margin: $gutter auto;
+.wayfinder_logo {
+  @include grid__unit--cols(6);
+  display: flex;
+}
+
+.wayfinder .logo-outer {
+  margin: 28px auto;
+  align-self: center;
+}
+
+.wayfinder_referrer {
+  @include grid__unit--cols(3);
+  padding: $gutter 0 $gutter ($gutter/2);
 }

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
@@ -1,0 +1,8 @@
+.wayfinder {
+  border-bottom: solid 1px $gray-8;
+}
+
+.wayfinder .logo {
+  display: block;
+  margin: $gutter auto;
+}

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
@@ -15,4 +15,5 @@
 .wayfinder_referrer {
   @include grid__unit--cols(3);
   padding: $gutter 0 $gutter ($gutter/2);
+  align-self: center;
 }

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
@@ -1,5 +1,10 @@
 .wayfinder {
+  display: none;
   border-bottom: solid 1px $gray-8;
+
+  @include breakpoint($bp-small) {
+    display: block;
+  }
 }
 
 .wayfinder_logo {

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
@@ -3,7 +3,7 @@
 }
 
 .wayfinder_logo {
-  @include grid__unit--cols(6);
+  @include grid__unit--cols(4);
   display: flex;
 }
 
@@ -13,7 +13,15 @@
 }
 
 .wayfinder_referrer {
-  @include grid__unit--cols(3);
-  padding: $gutter 0 $gutter ($gutter/2);
+  @include grid__unit--cols(4);
   align-self: center;
+  padding: $gutter-mobile 0;
+
+  @include breakpoint($bp-small) {
+    padding: $gutter-mobile 0 $gutter-mobile ($gutter-mobile / 2);
+  }
+
+  @include breakpoint($bp-med) {
+    padding: $gutter 0 $gutter ($gutter / 2);
+  }
 }

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.json
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.json
@@ -1,0 +1,7 @@
+{
+  "wayfinder": {
+    "logo": {
+      "href": "https://www.ama-assn.org"
+    }
+  }
+}

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.json
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.json
@@ -5,7 +5,7 @@
     },
     "referred": {
       "referrerHref": "http://some-page-on-d7.com",
-      "referrerTitle": "Referring page title text is long long long. Referring page title text is long long long. Referring page title text is long long long. "
+      "referrerTitle": "Title of d7 page"
     }
   }
 }

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.json
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.json
@@ -2,10 +2,6 @@
   "wayfinder": {
     "logo": {
       "href": "https://www.ama-assn.org"
-    },
-    "referred": {
-      "referrerHref": "http://some-page-on-d7.com",
-      "referrerTitle": "Title of d7 page"
     }
   }
 }

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.json
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.json
@@ -2,6 +2,10 @@
   "wayfinder": {
     "logo": {
       "href": "https://www.ama-assn.org"
+    },
+    "referred": {
+      "referrerHref": "http://some-page-on-d7.com",
+      "referrerTitle": "Referring page title text is long long long. Referring page title text is long long long. Referring page title text is long long long. "
     }
   }
 }

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.md
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.md
@@ -1,5 +1,5 @@
 ---
-title: "Topic Wayfinder"
+title: "Wayfinder"
 ---
 
 (drupal-specific): Provides a way to navigate back to the referring D7 page.

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.md
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.md
@@ -1,0 +1,7 @@
+---
+title: "Topic Wayfinder"
+---
+
+(drupal-specific): Provides a way to navigate back to the referring D7 page.
+
+See [EWL-4030](https://issues.ama-assn.org/browse/EWL-4030), [EWL-4016](https://issues.ama-assn.org/browse/EWL-4016)

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
@@ -9,6 +9,6 @@
       {% set href = wayfinder.logo.href %}
       {% include 'atoms-logo' %}
     </div>
-    <div class="col-width-3"></div>
+    <div class="col-width-4"></div>
   </div>
 </section>

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
@@ -1,8 +1,12 @@
 <section class="wayfinder">
   <div class="container grid">
-    <div class="col-width-12">
+    <div class="wayfinder_referrer">
+      A paragraph (from the Greek paragraphos, "to write beside" or "written beside") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose.
+    </div>
+    <div class="wayfinder_logo">
       {% set href = wayfinder.logo.href %}
       {% include 'atoms-logo' %}
     </div>
+    <div class="col-width-3"></div>
   </div>
 </section>

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
@@ -1,0 +1,8 @@
+<section class="wayfinder">
+  <div class="container grid">
+    <div class="col-width-12">
+      {% set href = wayfinder.logo.href %}
+      {% include 'atoms-logo' %}
+    </div>
+  </div>
+</section>

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
@@ -1,14 +1,17 @@
 <section class="wayfinder">
   <div class="container grid">
     <div class="wayfinder_referrer">
-      {% set url = wayfinder.referred.referrerHref %}
-      {% set content = wayfinder.referred.referrerTitle %}
-      {% include 'molecules-link-with-back-icon' %}
+    {% if wayfinder.referred %}
+        {% set url = wayfinder.referred.referrerHref %}
+        {% set content = wayfinder.referred.referrerTitle %}
+        {% include 'molecules-link-with-back-icon' %}
+    {% endif %}
     </div>
     <div class="wayfinder_logo">
       {% set href = wayfinder.logo.href %}
       {% include 'atoms-logo' %}
     </div>
+    {# Use an empty div here to take up space so the logo can be centered. #}
     <div class="col-width-4"></div>
   </div>
 </section>

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
@@ -1,7 +1,9 @@
 <section class="wayfinder">
   <div class="container grid">
     <div class="wayfinder_referrer">
-      A paragraph (from the Greek paragraphos, "to write beside" or "written beside") is a self-contained unit of a discourse in writing dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any language, paragraphs are usually an expected part of formal writing, used to organize longer prose.
+      {% set url = wayfinder.referred.referrerHref %}
+      {% set content = wayfinder.referred.referrerTitle %}
+      {% include 'molecules-link-with-back-icon' %}
     </div>
     <div class="wayfinder_logo">
       {% set href = wayfinder.logo.href %}

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder~referred.json
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder~referred.json
@@ -1,0 +1,8 @@
+{
+  "wayfinder": {
+    "referred": {
+      "referrerHref": "http://some-page-on-d7.com",
+      "referrerTitle": "Referring page title text"
+    }
+  }
+}

--- a/styleguide/source/_patterns/03-templates/04-topic/topic.twig
+++ b/styleguide/source/_patterns/03-templates/04-topic/topic.twig
@@ -1,8 +1,10 @@
 <header>
   {% include 'organisms-ribbon' %}
+  {% include 'organisms-wayfinder' %}
 </header>
 
 <main class="topic container">
+
   <div class="grid grid-margin">
     <div class="topic_top col-width-12 grid-region">
       {% include 'atoms-page-title' %}

--- a/styleguide/source/_patterns/03-templates/04-topic/topic~with-wayfinder-referred.json
+++ b/styleguide/source/_patterns/03-templates/04-topic/topic~with-wayfinder-referred.json
@@ -1,0 +1,8 @@
+{
+  "wayfinder": {
+    "referred": {
+      "referrerHref": "http://some-page-on-d7.com",
+      "referrerTitle": "Title of d7 page"
+    }
+  }
+}


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-4030: Topics |ENHANCEMENT | SG | Create & Style Wayfinder pattern](https://issues.ama-assn.org/browse/EWL-4030)


## Description

- Adds a new organism, "Wayfinder," to the style guide, as well as a "Wayfinder referred" pseudopattern.
- Adds the Wayfinder organism to the main Topic template pattern.
- Adds a "Topic with Wayfinder Referred" pseudopattern in Templates > Topic.
- Adds a new molecule, "Link with 'Back' Icon"


## To Test

- [ ] Templates > Topic: observe that the new Wayfinder pattern appears under the ribbon. Follow acceptance criteria from JIRA ticket.
- [ ] Templates > Topic with Wayfinder Referred: follow acceptance criteria from JIRA ticket.
- [ ] Organisms > Wayfinder: follow acceptance criteria from JIRA ticket. See that the `wayfinder.md` Pattern Info content exists and makes sense.
- [ ] Organisms > Wayfinder referred: follow acceptance criteria from JIRA ticket.
- [ ] Molecules > Link with 'Back' Icon: follow acceptance criteria from JIRA ticket. See that the `link-with-back-icon.md` Pattern Info content exists and makes sense.


## Relevant Screenshots/GIFs

![screen shot 2017-11-13 at 4 01 35 pm](https://user-images.githubusercontent.com/12160398/32751552-f44cf45a-c88b-11e7-84cd-8705c1c0d766.png)


## Remaining Tasks

N/A


## Additional Notes

- I know the empty `.col-width-4` in `wayfinder.twig` being used to preserve whitespace is not ideal, but I wasn't aware of a better solution. Suggestions welcome.
- This currently looks not great IMO at smaller breakpoints. I vaguely recall some kind of decision about Wayfinder not showing up on mobile at all; have reached out to Robert to confirm. In the meantime, leaving as-is.