### PR TITLE
EWL 4231: Remove LIs

### DIFF
--- a/styleguide/source/_patterns/01-molecules/08-lists/14-list-topic-related-articles/_list-topic-related-articles.scss
+++ b/styleguide/source/_patterns/01-molecules/08-lists/14-list-topic-related-articles/_list-topic-related-articles.scss
@@ -1,25 +1,16 @@
-.ama-theme {
-  .list_topic-related-articles {
-    list-style: none;
-    margin: 0;
-    max-width: $max-width;
-    padding: 0;
+.list_item-topic-related-article {
+  @include gutter($padding-top-half...);
+  @include gutter($padding-bottom-half...);
+  margin-bottom: 0;
 
-    .list_item-topic-related-article {
-      @include gutter($padding-top-half...);
-      @include gutter($padding-bottom-half...);
-      margin-bottom: 0;
-
-      &:not(:first-child) {
-        @include rule-horizontal(1px, $black-20, solid);
-      }
-    }
-
-    a {
-      @extend %text-transition;
-      &:hover {
-        color: $blue;
-      }
-    }
+  &:not(:first-of-type) {
+    @include rule-horizontal(1px, $black-20, solid);
   }
-} // closes .ama-theme
+}
+
+a {
+  @extend %text-transition;
+  &:hover {
+    color: $blue;
+  }
+}

--- a/styleguide/source/_patterns/01-molecules/08-lists/14-list-topic-related-articles/list-topic-related-articles.twig
+++ b/styleguide/source/_patterns/01-molecules/08-lists/14-list-topic-related-articles/list-topic-related-articles.twig
@@ -1,5 +1,3 @@
-<ul class="list_topic-related-articles">
-  <li class="list_item-topic-related-article">{% include 'molecules-article-preview' with { 'topic_article': listTopicRelatedArticles.first } %}</li>
-  <li class="list_item-topic-related-article">{% include 'molecules-article-preview' with { 'topic_article': listTopicRelatedArticles.second } %}</li>
-  <li class="list_item-topic-related-article">{% include 'molecules-article-preview' with { 'topic_article': listTopicRelatedArticles.third } %}</li>
-</ul>
+<div class="list_item-topic-related-article">{% include 'molecules-article-preview' with { 'topic_article': listTopicRelatedArticles.first } %}</div>
+<div class="list_item-topic-related-article">{% include 'molecules-article-preview' with { 'topic_article': listTopicRelatedArticles.second } %}</div>
+<div class="list_item-topic-related-article">{% include 'molecules-article-preview' with { 'topic_article': listTopicRelatedArticles.third } %}</div>


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.

**Jira Ticket**

- https://issues.ama-assn.org/browse/EWL-4231


## Description
Remove `<LI>` in favor of markup we can use on the Drupal side -- We need to be able to use multiple "View Modes" in one section. On the Drupal side, when using this with other View Modes we were getting `<li>` without a parent `<ul>`.


## To Test

- [ ] View http://localhost:3000/?p=templates-topic
- [ ] Verify that the `<li>`(s) have been removed and everything looks and functions right at all breakpoints. This is for the small related article.


## Relevant Screenshots/GIFs
![screen shot 2017-11-10 at 1 31 55 pm](https://user-images.githubusercontent.com/231467/32673060-8846e878-c61b-11e7-84b8-a9e6b17e957f.png)



## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add?
