### PR TITLE
EWL-4239 - Fix eye icon color

### DIFF
--- a/styleguide/source/_patterns/01-molecules/04-forms/01-form-item/_form-item.scss
+++ b/styleguide/source/_patterns/01-molecules/04-forms/01-form-item/_form-item.scss
@@ -215,7 +215,7 @@
     top: 1em;
     right: 55px;
     display: block;
-    background-image: url("../../assets/icons/svg/show.svg");
+    background-image: url("../../assets/icons/svg/hide.svg");
     background-repeat: no-repeat;
     background-size: 100%;
     width: 30px;
@@ -223,7 +223,19 @@
     z-index: 10;
 
     &.show {
+      background-image: url("../../assets/icons/svg/show.svg");
+    }
+  }
+
+  .form-item {
+    .form-item_password {
       background-image: url("../../assets/icons/svg/hide.svg");
+    }
+  }
+
+  .form-item:focus-within {
+    .form-item_password {
+      background-image: url("../../assets/icons/svg/show.svg");
     }
   }
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
- [EWL-4239: Style Guide | Eye icon color incorrect](https://issues.ama-assn.org/browse/EWL-4239)

## Description:
Eye color incorrect for password input fields. It should be grey when not in focus and black when in focus.

## To Test:
- [ ] Style Guide | http://localhost:3000/?p=molecules-input-password
- [ ] Check to see if the eye color is grey on blur and black in focus

## Automated Test:
N/A

## Relevant Screenshots/GIFs:
![screen shot 2017-11-14 at 9 30 43 am](https://user-images.githubusercontent.com/2271747/32788320-8b8fa8ca-c91e-11e7-8e73-1f266c567eea.png)
![screen shot 2017-11-14 at 9 30 51 am](https://user-images.githubusercontent.com/2271747/32788321-8b9c2208-c91e-11e7-97f0-130eedd7e4b3.png)


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
