### PR TITLE
EWL-4252: swap out the image atom for the figure molecule

### DIFF
--- a/styleguide/source/_patterns/02-organisms/03-sections/11-state-data-info/state-data-info.json
+++ b/styleguide/source/_patterns/02-organisms/03-sections/11-state-data-info/state-data-info.json
@@ -3,8 +3,7 @@
     "states": {
       "alabama": {
         "h3": "Alabama",
-        "paragraph": "From the American Civil War until World War II, Alabama, like many states in the southern U.S., suffered economic hardship, in part because of its continued dependence on agriculture. ",
-        "image": "https://ipsumimage.appspot.com/572x255"
+        "paragraph": "From the American Civil War until World War II, Alabama, like many states in the southern U.S., suffered economic hardship, in part because of its continued dependence on agriculture. "
       }
     }
   }

--- a/styleguide/source/_patterns/02-organisms/03-sections/11-state-data-info/state-data-info.twig
+++ b/styleguide/source/_patterns/02-organisms/03-sections/11-state-data-info/state-data-info.twig
@@ -3,8 +3,7 @@
   {% include 'atoms-h3' %}
   {% set content = stateDataPage.stateDataSelect.states.alabama.paragraph %}
   {% include 'atoms-paragraph' %}
-  {% set src = stateDataPage.stateDataSelect.states.alabama.image %}
-  {% include 'atoms-landscape-3x2' %}
+  {% include 'molecules-figure' %}
   {% set content = stateDataPage.stateDataSelect.states.alabama.downloads %}
   {% include 'molecules-list-rule-metadata' %}
 </div>


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)
Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.

**Github Issue**

- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**

- [EWL-4252: Ticket Title](https://issues.ama-assn.org/browse/EWL-4252)


## Description
Use the figure molecule instead of the image atom, since that is what is standard on the corp website.


## To Test

- [ ] Navigate to http://localhost:3000/?p=organisms-state-data-info
- [ ] Observe you see the figure organism 


## Relevant Screenshots/GIFs

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add?
