### PR TITLE
EWL-3858 Keep member pitch at the top on tablet.

### DIFF
--- a/styleguide/source/_patterns/03-templates/04-topic/_topic.scss
+++ b/styleguide/source/_patterns/03-templates/04-topic/_topic.scss
@@ -31,7 +31,7 @@
     grid-area: 3 / 1 / 3 / 1;
 
     @include breakpoint($bp-small) {
-      grid-area: 1 / 2 / 1 / 2;
+      grid-area: 2 / 2 / 2 / 2;
     }
 
     @include breakpoint($bp-med) {
@@ -57,7 +57,7 @@
     grid-area: 2 / 1 / 2 / 1;
 
     @include breakpoint($bp-small) {
-      grid-area: 2 / 2 / 2 / 2;
+      grid-area: 1 / 2 / 1 / 2;
     }
 
     @include breakpoint($bp-med) {


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.

**Github Issue**

NA

**Jira Ticket**

- [EWL-3858: Mobile sort order](https://issues.ama-assn.org/browse/EWL-3858)


## Description

It wasn't described well in the ticket and I think we missed this in the review of #255, but the new region was displaying lower on tablet and I think it should be at the top there too. This fixes that behavior.

## To Test

- Observe the topic-member-right region is at the top of the right sidebar on tablet and desktop, and stacks above all other sidebar content on mobile.
- Observe nothing else breaks.

<img width="809" alt="pattern_lab_-_templates-topic" src="https://user-images.githubusercontent.com/238201/33281973-b3d38e52-d36c-11e7-98f0-f8a082138b2d.png">



## Relevant Screenshots/GIFs

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add?
