### PR TITLE
Update release task to push to dev-assets.

### DIFF
--- a/docs/creating_a_release.md
+++ b/docs/creating_a_release.md
@@ -13,7 +13,7 @@ _WARNING: This should only be run on the `develop` branch!**\***_
 - Make sure you are running the most up-to-date code
   - Updates will be rejected if they are non-fast-forward
 - Update `package.json` with the new version number.
-- `gulp release` to build the files correctly, cut a tag, and deploy the files to _both_ `gh-pages` and `master`.
+- `gulp release` to build the files correctly, cut a tag, and deploy the files to `gh-pages`, `dev-assets`, and `master`.
 - Navigate to the [latest release](https://github.com/AmericanMedicalAssociation/AMA-style-guide/releases) to see the new release and add notes.
 
 Initial config via [TutsPlus](https://webdesign.tutsplus.com/tutorials/combining-pattern-lab-with-gulp-for-improved-workflow--cms-22187).

--- a/styleguide/gulpfile.js
+++ b/styleguide/gulpfile.js
@@ -303,13 +303,20 @@ gulp.task('set-master', function (callback) {
   callback();
 })
 
+gulp.task('set-dev-assets', function (callback) {
+  // Change the deploy branch
+  gutil.log('Setting branch to dev-assets.');
+  config.deployment.branch = "dev-assets";
+  callback();
+})
+
 // Task: Release the code
-// Description: Release runs deploy to build to gh-pages,
+// Description: Release runs deploy to build to gh-pages and dev-assets,
 // pushes the same code to master, then tags master.
 gulp.task('release', function (callback) {
   // make sure to use the gulp from node_modules and not a different version
   runSequence = require('run-sequence').use(gulp);
   // Build the style guide, publish to gh-pages, set the branch to master,
   // publish to master, then tag master.
-  runSequence('default', 'publish', 'set-master', 'publish', 'tag', callback);
+  runSequence('default', 'publish', 'set-dev-assets', 'publish', 'set-master', 'publish', 'tag', callback);
 });


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.

**Github Issue**

- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/XXX)

**Jira Ticket**

NA

## Description

I'm not sure why, but `gulp release` didn't previously push to `dev-assets`. This resulted in more than one instance of releases that didn't include pushes there. This now pushes to all the things on `release`.

## To Test

- Change line 264 of gulpfile.js to `    .pipe(ghPages({ branch: config.deployment.branch, push: false}));` so that you can test without pushing
- Run `gulp release`
- Observe commits to `dev-assets`, `master`, and `gh-pages`.


## Relevant Screenshots/GIFs

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add?
