### PR TITLE
[EWL-4344] SG | Topics template doesn't show Lead News title

### DIFF
--- a/styleguide/source/_patterns/02-organisms/06-topic/10-topic-lead-news/topic-lead-news.json
+++ b/styleguide/source/_patterns/02-organisms/06-topic/10-topic-lead-news/topic-lead-news.json
@@ -1,6 +1,6 @@
 {
   "leadNewsBlock": {
-    "label": "Lead News Topic Label",
+    "label": "Label text for Lead News block",
     "articles": {
       "first": {
         "viewMode": "hero",

--- a/styleguide/source/_patterns/02-organisms/06-topic/10-topic-lead-news/topic-lead-news.twig
+++ b/styleguide/source/_patterns/02-organisms/06-topic/10-topic-lead-news/topic-lead-news.twig
@@ -3,6 +3,10 @@
   {% include 'molecules-in-place-editor' %}
   {% endif %}
 <div class="topic_lead-news">
+  {% if leadNewsBlock.label %}
+    {% set content = leadNewsBlock.label %}
+    {% include 'atoms-title-label' %}
+  {% endif %}
   {% for article in leadNewsBlock.articles %}
     {% if article.viewMode == "hero" or article.viewMode == "hero-no-media" %}
       {% set class = 'topic_hero' %}


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-4344: SG | Topics template doesn't show Lead News title](https://issues.ama-assn.org/browse/EWL-4344)


## Description

- Added an include for the block label at the top of the block.


## To Test

- [x] Organisms > Topic > Topic Lead News Block - view the title and make sure it looks good
- [x] Templates > Topic > Topic - view the title and make sure it looks good


## Relevant Screenshots/GIFs

![screen shot 2017-12-11 at 11 44 50 am](https://user-images.githubusercontent.com/12160398/33845329-b694797e-de68-11e7-9218-4a95bd147278.png)



## Remaining Tasks

N/A


## Additional Notes

N/A
