### PR TITLE
Removes extra padding and height to the wayfinder.

### DIFF
--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/_wayfinder.scss
@@ -13,8 +13,9 @@
 }
 
 .wayfinder_logo .logo-outer {
-  margin: $gutter auto;
-  align-self: center;
+  margin: 0 auto;
+  align-items: center;
+  display: flex;
 }
 
 .wayfinder_referrer {
@@ -27,7 +28,7 @@
   }
 
   @include breakpoint($bp-med) {
-    padding: $gutter 0 $gutter ($gutter / 2);
+    padding: ($gutter / 2) 0;
   }
 
   .link-back {

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.js
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.js
@@ -12,13 +12,6 @@
     attach: function (context, settings) {
       (function ($) {
 
-        var pageTitle  = document.title.replace(' | AMA', '');
-        var pageUrl = window.location.href;
-        $.cookie.json = true;
-        $.cookie('ama_wayfinder_cookie', [pageTitle, pageUrl], { expires: 1, path: '/'});
-
-        console.log($.cookie('ama_wayfinder_cookie'))
-
         // Read wayfinder cookies set from ama-assn domains
         $.cookie.json = true;
         var ama_wayfinder_cookie = $.cookie('ama_wayfinder_cookie');

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.js
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.js
@@ -11,12 +11,20 @@
   Drupal.behaviors.wayfinder = {
     attach: function (context, settings) {
       (function ($) {
+
+        var pageTitle  = document.title.replace(' | AMA', '');
+        var pageUrl = window.location.href;
+        $.cookie.json = true;
+        $.cookie('ama_wayfinder_cookie', [pageTitle, pageUrl], { expires: 1, path: '/'});
+
+        console.log($.cookie('ama_wayfinder_cookie'))
+
         // Read wayfinder cookies set from ama-assn domains
         $.cookie.json = true;
         var ama_wayfinder_cookie = $.cookie('ama_wayfinder_cookie');
         
         if (typeof ama_wayfinder_cookie !== 'undefined') {
-          $('.wayfinder_referrer .link-back').show();
+          $('.wayfinder_referrer .link-back').show().css('display', 'flex');
           $('.link-back').attr("href", ama_wayfinder_cookie[1]);
           $('.link-back .link-back_text').text(ama_wayfinder_cookie[0]);
         } else {

--- a/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
+++ b/styleguide/source/_patterns/02-organisms/00-global/06-wayfinder/wayfinder.twig
@@ -11,7 +11,5 @@
       {% set href = wayfinder.logo.href %}
       {% include 'atoms-logo' %}
     </div>
-    {# Use an empty div here to take up space so the logo can be centered. #}
-    <div class="col-width-4"></div>
   </div>
 </section>


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant ticket! If you are creating a new pattern or feature, create an issue describing the need for this feature Github **first** and then link to it below.

**Github Issue**

- [277: Wayfinder Height](https://github.com/AmericanMedicalAssociation/AMA-style-guide/issues/277)

**Does not have a linked to story because Jira is down!**

## Description

- Removes padding and height to wayfinder per UX request
- Wayfinder expands depending on the length of the link content

## To Test

- [ ] Put this snippet in the the wayfinder.js to create a cookie.
`    var pageTitle  = document.title.replace(' | AMA', '');
        var pageUrl = window.location.href;
        $.cookie.json = true;
        $.cookie('ama_wayfinder_cookie', [pageTitle, pageUrl], { expires: 1, path: '/'});
`
don't commit it.
- [ ] gulp serve
- [ ] Look for wayfinder in organisms/global/wayfinder-referred


## Relevant Screenshots/GIFs
![screen shot 2017-12-15 at 9 38 21 am](https://user-images.githubusercontent.com/2271747/34049084-b72f87aa-e17b-11e7-9246-47cda9f54c91.png)


## Remaining Tasks

This needs to get tested in D8

## Additional Notes

The wayfinder will not show unless there is a cookie called ama_wayfinder. 