### PR TITLE
EWL-4740: Fix wayfinder arrow icon position

### DIFF
--- a/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/_link-with-back-icon.scss
+++ b/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/_link-with-back-icon.scss
@@ -9,6 +9,7 @@
 
 .link-back_icon .icon-select {
   transform: rotate(90deg); // adjust the positioning of the icon so it lines up with the text and the container edge.
+  line-height: 12px;
 }
 
 .link-back_text {

--- a/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/_link-with-back-icon.scss
+++ b/styleguide/source/_patterns/01-molecules/00-text/06-link-with-back-icon/_link-with-back-icon.scss
@@ -8,7 +8,7 @@
 }
 
 .link-back_icon .icon-select {
-  transform: rotate(90deg) translateY(-4px) translateX(7px); // adjust the positioning of the icon so it lines up with the text and the container edge.
+  transform: rotate(90deg); // adjust the positioning of the icon so it lines up with the text and the container edge.
 }
 
 .link-back_text {


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWL-4740: CORP | Wayfinder arrow not in correct spot](https://issues.ama-assn.org/browse/EWL-4740)


## Description

Wayfinder arrow icon does not align with the link text 

## To Test

- [ ] Go to: http://localhost:3000/?p=organisms-wayfinder-referred
- [ ] To create a wayfinder link via a cookie open Chrome inspector - > console tab 
- [ ] Paste this into the console window
```

      var pageTitle = document.title.replace(' | AMA', '').replace(' | American Medical Association', '');
      var pageUrl = window.location.href;
      $.cookie.json = true;
      $.cookie('ama_wayfinder_cookie', [pageTitle, pageUrl], { expires: 1, path: '/'});

```
- [ ] Reload page
- [ ] Observe the wayfinder arrow is now inline with the link


## Relevant Screenshots/GIFs

<img width="1337" alt="screen shot 2018-03-15 at 4 02 01 pm" src="https://user-images.githubusercontent.com/2271747/37490950-393e3d9c-286a-11e8-928f-083242c6ccb1.png">


## Remaining Tasks
N/A


## Additional Notes

N/A