### PR TITLE
Bugfix/ewl 5496 deprecate sg1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [![Latest Release](https://img.shields.io/github/release/AmericanMedicalAssociation/AMA-style-guide.svg)](https://github.com/AmericanMedicalAssociation/AMA-style-guide/releases/latest)
 
-# Living Style Guide for AMA
-This is the living style guide for the American Medical Association. It is a platform-agnostic tool to empower employees and vendors to maintain consistent design and hierarchy throughout the AMA digital ecosystem.
+# DEPRECATED Living Style Guide for AMA
+
+## This style guide has been DEPRECATED. The AMA is now maintaining consistent design and hierarchy through the [AMA Style Guide 2](https://github.com/AmericanMedicalAssociation/AMA-style-guide-2) which can be previewed on [GitHub Pages](https://americanmedicalassociation.github.io/ama-style-guide-2/)
+This is a **deprecated** living style guide for the American Medical Association. It is a platform-agnostic tool to empower employees and vendors to maintain consistent design and hierarchy throughout the AMA digital ecosystem.
 
 This style guide is a compilation of [atomic components](http://bradfrost.com/blog/post/atomic-web-design/) that have been specifically tailored to the needs of AMA. By documenting and assembling this collection of patterns, we are able to build consistently, reuse code, and [see all of our patterns in one place](https://americanmedicalassociation.github.io/AMA-style-guide/).
 

--- a/styleguide/source/_patterns/00-atoms/00-intro/00-intro.twig
+++ b/styleguide/source/_patterns/00-atoms/00-intro/00-intro.twig
@@ -1,6 +1,7 @@
 <div class="sg-introduction container">
   <h2>{% include 'atoms-logo' %}</h2>
-  <h1>Welcome to the AMA Style Guide</h1>
+  <h1>Welcome to the <strong>DEPRECATED</strong> AMA Style Guide</h1>
+  <p><strong>This style guide has been DEPRECATED. The AMA is now maintaining consistent design and hierarchy through the <a href="https://github.com/AmericanMedicalAssociation/AMA-style-guide-2">AMA Style Guide 2</a> which can be previewed on <a href="https://americanmedicalassociation.github.io/ama-style-guide-2/">GitHub Pages</a></strong></p>
   <p>Click the "all" link or navigation above to browse styles. You can search for patterns using "Find Pattern" in the gear on the right. View the <a href="https://github.com/AmericanMedicalAssociation/AMA-style-guide/releases/latest" class="link">latest release <img src="https://img.shields.io/github/release/AmericanMedicalAssociation/AMA-style-guide.svg" alt="Latest Release"></a> or {% include '00-link.twig' with {'content' : 'development code', 'url' : 'https://github.com/AmericanMedicalAssociation/AMA-style-guide'}%} on GitHub.
   <h2>Working with our style guide</h2>
   <h3>Structure</h3>


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)
**Jira Ticket**

- [EWL-5496: Deprecate SG1](https://issues.ama-assn.org/browse/EWL-5496)


## Description
Note the Deprecation on the `README` and intro pattern in Pattern Lab

I did **not** note it on every pattern because I started to do that and then realized that note would cascade everywhere the pattern was used. How would you like me to move forward with this need? 


## To Test

- [ ] Navigate to `README`
- [ ] Observe it says in large text that the style guide is deprecated
- [ ] Observe it links to SG2 repo
- [ ] Observe it links to SG2 GitHub pages site
- [ ] `gulp serve`
- [ ] Navigate to intro pattern
- [ ] Observe it says in large text that the style guide is deprecated
- [ ] Observe it links to SG2 repo
- [ ] Observe it links to SG2 GitHub pages site

## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A

## Additional Notes
N/A
